### PR TITLE
feat: add GGUFRS model packages and load planning

### DIFF
--- a/RustModelInference/Cargo.toml
+++ b/RustModelInference/Cargo.toml
@@ -22,6 +22,7 @@ tokio-stream = "0.1"
 tower-http = { version = "0.6", features = ["cors"] }
 rand = "0.8"
 unicode_categories = "0.1"
+sha2 = "0.10"
 
 [profile.release]
 opt-level = 3

--- a/RustModelInference/GGUFRS.md
+++ b/RustModelInference/GGUFRS.md
@@ -1,0 +1,132 @@
+# GGUFRS v1
+
+GGUFRS is a RustModelInference package for model management and device-independent loading. It bundles exactly one LLM GGUF and optionally one mmproj GGUF while preserving component metadata and original tensor bytes. It is not readable by llama.cpp and does not replace ordinary GGUF interchange.
+
+All integers are little-endian. Offsets and byte lengths are `u64`; counts and stable IDs are `u32`. Strings are `u64 byte_length` followed by UTF-8 bytes. GGUF metadata and GGML tensor type numeric codes are reused.
+
+## Physical order
+
+```text
+128-byte superblock
+component table
+component-scoped metadata table
+segment table
+tensor table
+zero alignment padding
+64 KiB-aligned tensor segments
+```
+
+No component or directory is appended after tensor data. The last segment ends at the declared file size.
+
+## Superblock
+
+| Offset | Size | Field |
+|---:|---:|---|
+| 0 | 8 | magic `b"GGUFRS\0\0"` |
+| 8 | 4 | version, `1` |
+| 12 | 4 | flags, `0` in v1 |
+| 16 | 8 | declared file size |
+| 24 | 4 | component count |
+| 28 | 4 | metadata count |
+| 32 | 4 | segment count |
+| 36 | 4 | tensor count |
+| 40 | 8 | component table offset |
+| 48 | 8 | component table length |
+| 56 | 8 | metadata table offset |
+| 64 | 8 | metadata table length |
+| 72 | 8 | segment table offset |
+| 80 | 8 | segment table length |
+| 88 | 8 | tensor table offset |
+| 96 | 8 | tensor table length |
+| 104 | 8 | tensor-data offset |
+| 112 | 16 | reserved zero bytes |
+
+Readers reject unsupported versions, nonzero flags/reserved bytes, unordered or noncontiguous tables, nonzero table padding, invalid ranges, appended data, and a declared size different from the actual file size.
+
+## Component table
+
+Each entry is:
+
+```text
+u32 component_id
+u32 role                 # 1 = LLM, 2 = MMPROJ
+string name              # canonical "llm" or "mmproj"
+u32 metadata_start
+u32 metadata_count
+u32 tensor_start
+u32 tensor_count
+u32 segment_start
+u32 segment_count
+```
+
+V1 requires exactly one LLM and at most one mmproj. Components are ordered by role then UTF-8 name bytes; IDs are their table indices.
+
+## Scoped metadata table
+
+Each entry is:
+
+```text
+u32 component_id
+string key
+i32 GGUF value_type
+typed GGUF value
+```
+
+Array encoding is `i32 element_type`, `u64 count`, then homogeneous values. Metadata is sorted by component and key bytes. Duplicate keys inside one component are invalid; identical keys in different components remain independent.
+
+## Segment table
+
+Each 72-byte entry is:
+
+```text
+u32 segment_id
+u32 component_id
+u32 kind                 # 1 = shared, 2 = layer, 3 = component
+i32 layer                # layer index, or -1
+u64 absolute_offset
+u64 stored_length
+u32 tensor_start
+u32 tensor_count
+u8 sha256[32]
+```
+
+The LLM has one shared segment and one segment for every layer. The mmproj has one component segment. Segment starts and stored lengths are multiples of 64 KiB and segments are contiguous. SHA-256 covers the complete stored segment, including inter-tensor and trailing zero padding. A segment can therefore be verified, mapped, and released independently.
+
+## Tensor table and bytes
+
+Each entry is:
+
+```text
+u32 component_id
+u32 segment_id
+string tensor_name
+i32 GGML type
+u32 rank
+u64 dims[rank]
+u64 offset_within_segment
+u64 exact_byte_length
+```
+
+Tensors are sorted by name bytes inside each segment. Offsets use `max(32, general.alignment)` for that component. Shapes, quantization block sizes, ranges, and overlaps are validated before mapping.
+
+The exporter copies `GGUFLoader::tensor_slice(name)` directly. It never dequantizes, requantizes, repacks, or converts tensor data through floating point. Identical source bytes and options therefore produce byte-identical packages; source paths, timestamps, host devices, and temporary names are not serialized.
+
+## Export and publication
+
+```bash
+cargo run --release --bin ggufrs -- \
+  export \
+  --llm model.gguf \
+  --mmproj mmproj.gguf \
+  --output model.ggufrs
+```
+
+`--mmproj` is optional. The default never replaces an output. `--overwrite` requests atomic replacement. Export writes a unique file in the output directory, syncs it, reopens it through the production reader, verifies every segment, then publishes it. Unsupported atomic publication returns an error and never deletes the destination first.
+
+## Runtime and load planning
+
+`TensorSource` is the common read-only interface for GGUF and a loaded GGUFRS component. Runtime format selection uses file magic, not the extension. An explicit `--mmproj` overrides the bundled component.
+
+`LayerSplit` keeps each layer segment whole and assigns contiguous layer ranges to caller-provided logical devices. Shared and mmproj tensors stay on the declared primary device. `TensorSplit` may divide a tensor only between complete rows; quantized rows must contain complete quantization blocks. Capacity counts tensor payload, not table or padding bytes.
+
+V1 executes a plan only against logical CPU devices to verify deterministic placement and mapping lifetimes. Metal, CUDA, NPU, transfers, and execution scheduling are future backends; they do not change this file format.

--- a/RustModelInference/GGUFRS.md
+++ b/RustModelInference/GGUFRS.md
@@ -121,7 +121,7 @@ cargo run --release --bin ggufrs -- \
   --output model.ggufrs
 ```
 
-`--mmproj` is optional. The default never replaces an output. `--overwrite` requests atomic replacement. Export writes a unique file in the output directory, syncs it, reopens it through the production reader, verifies every segment, then publishes it. Unsupported atomic publication returns an error and never deletes the destination first.
+`--mmproj` is optional. The default never replaces an output. `--overwrite` requests atomic replacement. Export writes a unique file in the output directory, retains and syncs its `create_new` handle, verifies every segment through a clone of that handle and the production reader, then publishes it. Unsupported atomic publication returns an error and never deletes the destination first.
 
 ## Runtime and load planning
 

--- a/RustModelInference/src/bin/ggufrs.rs
+++ b/RustModelInference/src/bin/ggufrs.rs
@@ -16,9 +16,13 @@ enum Command {
 }
 
 fn take_value(args: &mut VecDeque<OsString>, flag: &str) -> Result<PathBuf, String> {
-    args.pop_front()
-        .map(PathBuf::from)
-        .ok_or_else(|| format!("Missing value for {flag}"))
+    let value = args
+        .pop_front()
+        .ok_or_else(|| format!("Missing value for {flag}"))?;
+    if value.as_os_str().as_encoded_bytes().starts_with(b"--") {
+        return Err(format!("Missing value for {flag}"));
+    }
+    Ok(PathBuf::from(value))
 }
 
 fn parse_args(args: impl IntoIterator<Item = OsString>) -> Result<Command, String> {
@@ -127,6 +131,8 @@ mod tests {
             vec!["export", "--llm"],
             vec!["export", "--llm", "a.gguf"],
             vec!["export", "--output", "a.ggufrs"],
+            vec!["export", "--llm", "--overwrite", "--output", "x.ggufrs"],
+            vec!["export", "--llm", "a.gguf", "--output", "--output"],
             vec![
                 "export", "--llm", "a.gguf", "--llm", "b.gguf", "--output", "x.ggufrs",
             ],

--- a/RustModelInference/src/bin/ggufrs.rs
+++ b/RustModelInference/src/bin/ggufrs.rs
@@ -1,0 +1,146 @@
+use rust_model_inference::{export_ggufrs, ExportOptions};
+use std::collections::VecDeque;
+use std::ffi::{OsStr, OsString};
+use std::path::PathBuf;
+
+const USAGE: &str = "Usage: ggufrs export --llm <model.gguf> [--mmproj <mmproj.gguf>] --output <model.ggufrs> [--overwrite]";
+
+#[derive(Debug, PartialEq, Eq)]
+enum Command {
+    Export {
+        llm: PathBuf,
+        mmproj: Option<PathBuf>,
+        output: PathBuf,
+        overwrite: bool,
+    },
+}
+
+fn take_value(args: &mut VecDeque<OsString>, flag: &str) -> Result<PathBuf, String> {
+    args.pop_front()
+        .map(PathBuf::from)
+        .ok_or_else(|| format!("Missing value for {flag}"))
+}
+
+fn parse_args(args: impl IntoIterator<Item = OsString>) -> Result<Command, String> {
+    let mut args: VecDeque<OsString> = args.into_iter().collect();
+    if args.pop_front().as_deref() != Some(OsStr::new("export")) {
+        return Err("Expected the export command".into());
+    }
+    let mut llm = None;
+    let mut mmproj = None;
+    let mut output = None;
+    let mut overwrite = false;
+    while let Some(flag) = args.pop_front() {
+        if flag == OsStr::new("--llm") {
+            if llm.is_some() {
+                return Err("Duplicate --llm".into());
+            }
+            llm = Some(take_value(&mut args, "--llm")?);
+        } else if flag == OsStr::new("--mmproj") {
+            if mmproj.is_some() {
+                return Err("Duplicate --mmproj".into());
+            }
+            mmproj = Some(take_value(&mut args, "--mmproj")?);
+        } else if flag == OsStr::new("--output") {
+            if output.is_some() {
+                return Err("Duplicate --output".into());
+            }
+            output = Some(take_value(&mut args, "--output")?);
+        } else if flag == OsStr::new("--overwrite") {
+            if overwrite {
+                return Err("Duplicate --overwrite".into());
+            }
+            overwrite = true;
+        } else {
+            return Err(format!("Unknown argument {:?}", flag));
+        }
+    }
+    Ok(Command::Export {
+        llm: llm.ok_or("Missing required --llm")?,
+        mmproj,
+        output: output.ok_or("Missing required --output")?,
+        overwrite,
+    })
+}
+
+fn main() {
+    let command = parse_args(std::env::args_os().skip(1)).unwrap_or_else(|error| {
+        eprintln!("{error}\n{USAGE}");
+        std::process::exit(2);
+    });
+    match command {
+        Command::Export {
+            llm,
+            mmproj,
+            output,
+            overwrite,
+        } => export_ggufrs(
+            &output,
+            &llm,
+            mmproj.as_deref(),
+            ExportOptions { overwrite },
+        )
+        .unwrap_or_else(|error| {
+            eprintln!("Failed to export {}: {error}", output.display());
+            std::process::exit(1);
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args<'a>(values: &'a [&'a str]) -> impl Iterator<Item = OsString> + 'a {
+        values.iter().map(OsString::from)
+    }
+
+    #[test]
+    fn parses_export_with_optional_mmproj_and_overwrite() {
+        assert_eq!(
+            parse_args(args(&[
+                "export",
+                "--llm",
+                "model.gguf",
+                "--mmproj",
+                "mmproj.gguf",
+                "--output",
+                "model.ggufrs",
+                "--overwrite",
+            ]))
+            .unwrap(),
+            Command::Export {
+                llm: "model.gguf".into(),
+                mmproj: Some("mmproj.gguf".into()),
+                output: "model.ggufrs".into(),
+                overwrite: true,
+            }
+        );
+    }
+
+    #[test]
+    fn export_arguments_are_strict_and_complete() {
+        for invalid in [
+            vec![],
+            vec!["inspect"],
+            vec!["export"],
+            vec!["export", "--llm"],
+            vec!["export", "--llm", "a.gguf"],
+            vec!["export", "--output", "a.ggufrs"],
+            vec![
+                "export", "--llm", "a.gguf", "--llm", "b.gguf", "--output", "x.ggufrs",
+            ],
+            vec!["export", "--llm", "a.gguf", "--output", "x.ggufrs", "extra"],
+            vec![
+                "export",
+                "--llm",
+                "a.gguf",
+                "--output",
+                "x.ggufrs",
+                "--unknown",
+            ],
+        ] {
+            assert!(parse_args(args(&invalid)).is_err(), "accepted {invalid:?}");
+        }
+    }
+}

--- a/RustModelInference/src/bin/server.rs
+++ b/RustModelInference/src/bin/server.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::sync::Arc;
 
 use axum::{
@@ -16,6 +17,7 @@ use tower_http::cors::CorsLayer;
 use rust_model_inference::*;
 
 struct Qwen3State {
+    source: Arc<dyn TensorSource>,
     layers: Vec<LayerWeightsOwned>,
     output_norm: Vec<f32>,
     embd_weight: &'static [u8],
@@ -26,6 +28,7 @@ struct Qwen3State {
 }
 
 struct Qwen35State {
+    source: Arc<dyn TensorSource>,
     model: Arc<Qwen35Model>,
     tokenizer: Arc<BPETokenizer>,
     pool: Arc<thread_pool::ComputePool>,
@@ -404,6 +407,7 @@ fn generate_qwen3(
     max_tokens: usize,
     temperature: f32,
 ) -> Result<GenerateResult, String> {
+    let _source = &s.source;
     let cfg = &s.config;
     let n_embd = cfg.n_embd;
     let n_layer = cfg.n_layer;
@@ -681,9 +685,7 @@ fn generate_qwen3(
                 let sc = unsafe { std::slice::from_raw_parts(sc, n_embd / 32) };
                 let gate_buf = unsafe { std::slice::from_raw_parts_mut(gate_buf_ptr, n_ff) };
                 let up_buf = unsafe { std::slice::from_raw_parts_mut(up_buf_ptr, n_ff) };
-                matmul_q8_0_quantized_parallel_rows(
-                    w_gate, q8, sc, up_buf, n_embd, n_ff, ith, nth,
-                );
+                matmul_q8_0_quantized_parallel_rows(w_gate, q8, sc, up_buf, n_embd, n_ff, ith, nth);
                 matmul_q8_0_quantized_parallel_rows(w_up, q8, sc, gate_buf, n_embd, n_ff, ith, nth);
                 let rows_per = n_ff / nth;
                 let r_start = ith * rows_per;
@@ -795,6 +797,7 @@ fn generate_qwen35(
     max_tokens: usize,
     temperature: f32,
 ) -> Result<GenerateResult, String> {
+    let _source = &state.source;
     let prompt_ids = server_prompt_tokens(&state.tokenizer, messages)?;
     let (prompt_positions, mut next_text_position) =
         build_qwen35_positions(&prompt_ids, None, &[])?;
@@ -899,11 +902,15 @@ fn generate_qwen35(
     })
 }
 
-fn get_f32_tensor_from_loader(loader: &GGUFLoader, name: &str, expected_len: usize) -> Vec<f32> {
-    let ti = loader
+fn get_f32_tensor_from_source(
+    source: &dyn TensorSource,
+    name: &str,
+    expected_len: usize,
+) -> Vec<f32> {
+    let ti = source
         .tensor_info(name)
         .unwrap_or_else(|| panic!("tensor {} not found", name));
-    let slice = loader
+    let slice = source
         .tensor_slice(name)
         .unwrap_or_else(|| panic!("slice {} not found", name));
     let mut out = vec![0.0f32; expected_len];
@@ -963,41 +970,44 @@ async fn main() {
     }
 
     if model_path.is_empty() {
-        eprintln!("Usage: rust-model-server --model <path.gguf> [--host 0.0.0.0] [--port 8080] [--threads 4]");
+        eprintln!("Usage: rust-model-server --model <path.gguf-or-ggufrs> [--host 0.0.0.0] [--port 8080] [--threads 4]");
         std::process::exit(1);
     }
 
     let n_threads = if n_threads > 0 { n_threads } else { 4 };
     eprintln!("Loading model: {} ...", model_path);
 
-    let loader = Arc::new(GGUFLoader::from_file(&model_path).unwrap_or_else(|e| {
-        eprintln!("Failed to load model: {}", e);
-        std::process::exit(1);
-    }));
-    let arch = loader
+    let source: Arc<dyn TensorSource> = Arc::from(
+        open_model_source(Path::new(&model_path), ComponentRole::Llm).unwrap_or_else(|error| {
+            eprintln!("Failed to load model: {error}");
+            std::process::exit(1);
+        }),
+    );
+    let arch = source
         .metadata("general.architecture")
         .and_then(|v| v.to_string_val())
         .unwrap_or_default();
     let pool = Arc::new(thread_pool::ComputePool::new(n_threads));
 
-    let tokenizer = BPETokenizer::from_gguf_metadata(|k| loader.metadata(k).cloned())
+    let tokenizer = BPETokenizer::from_gguf_metadata(|k| source.metadata(k).cloned())
         .unwrap_or_else(|e| {
             eprintln!("Failed to init tokenizer: {}", e);
             std::process::exit(1);
         });
 
     let model: ModelBackend = if arch == "qwen35" {
-        let model = Qwen35Model::from_gguf(&loader).unwrap_or_else(|e| {
+        let model = Qwen35Model::from_source(source.as_ref()).unwrap_or_else(|e| {
             eprintln!("Failed to parse Qwen3.5 model: {}", e);
             std::process::exit(1);
         });
         ModelBackend::Qwen35(Qwen35State {
+            source: Arc::clone(&source),
             model: Arc::new(model),
             tokenizer: Arc::new(tokenizer),
             pool,
         })
     } else {
-        let config = loader.model_config().unwrap_or_else(|e| {
+        let config = model_config_from_source(source.as_ref()).unwrap_or_else(|e| {
             eprintln!("Failed to parse config: {}", e);
             std::process::exit(1);
         });
@@ -1007,13 +1017,13 @@ async fn main() {
         let n_head_kv = config.n_head_kv;
         let n_embd_head = config.n_embd_head;
         let n_embd_head_k =
-            if let Some(v) = loader.metadata(&format!("{}.attention.key_length", arch)) {
+            if let Some(v) = source.metadata(&format!("{}.attention.key_length", arch)) {
                 v.to_u64().unwrap_or(n_embd_head as u64) as usize
             } else {
                 n_embd_head
             };
         let n_embd_head_v =
-            if let Some(v) = loader.metadata(&format!("{}.attention.value_length", arch)) {
+            if let Some(v) = source.metadata(&format!("{}.attention.value_length", arch)) {
                 v.to_u64().unwrap_or(n_embd_head as u64) as usize
             } else {
                 n_embd_head
@@ -1025,99 +1035,91 @@ async fn main() {
         let n_ctx = config.n_ctx.min(4096);
         let is_qwen3 = arch == "qwen3";
 
-        let output_norm = get_f32_tensor_from_loader(&loader, "output_norm.weight", n_embd);
-        let embd_weight = unsafe {
-            std::mem::transmute::<&[u8], &'static [u8]>(
-                loader.tensor_slice("token_embd.weight").expect("no embd"),
-            )
-        };
-        let output_weight = unsafe {
-            std::mem::transmute::<&[u8], &'static [u8]>(
-                loader
-                    .tensor_slice("output.weight")
-                    .unwrap_or(loader.tensor_slice("token_embd.weight").unwrap()),
+        let output_norm = get_f32_tensor_from_source(source.as_ref(), "output_norm.weight", n_embd);
+        let (embd_weight, output_weight) = unsafe {
+            // SAFETY: every slice comes from the immutable `source` Arc stored in the
+            // same state, and this task does not expose source/segment unloading.
+            (
+                std::mem::transmute::<&[u8], &'static [u8]>(
+                    source.tensor_slice("token_embd.weight").expect("no embd"),
+                ),
+                std::mem::transmute::<&[u8], &'static [u8]>(
+                    source
+                        .tensor_slice("output.weight")
+                        .unwrap_or(source.tensor_slice("token_embd.weight").unwrap()),
+                ),
             )
         };
 
         let layers: Vec<LayerWeightsOwned> = (0..n_layer)
-            .map(|l| LayerWeightsOwned {
-                attn_norm: get_f32_tensor_from_loader(
-                    &loader,
-                    &format!("blk.{}.attn_norm.weight", l),
-                    n_embd,
-                ),
-                ffn_norm: get_f32_tensor_from_loader(
-                    &loader,
-                    &format!("blk.{}.ffn_norm.weight", l),
-                    n_embd,
-                ),
-                q_norm: if is_qwen3 {
-                    Some(get_f32_tensor_from_loader(
-                        &loader,
-                        &format!("blk.{}.attn_q_norm.weight", l),
-                        n_embd_head_k,
-                    ))
-                } else {
-                    None
-                },
-                k_norm: if is_qwen3 {
-                    Some(get_f32_tensor_from_loader(
-                        &loader,
-                        &format!("blk.{}.attn_k_norm.weight", l),
-                        n_embd_head_k,
-                    ))
-                } else {
-                    None
-                },
-                wq: unsafe {
-                    std::mem::transmute::<&[u8], &'static [u8]>(
-                        loader
+            .map(|l| unsafe {
+                // SAFETY: every slice comes from the immutable `source` Arc stored in the
+                // same state, and this task does not expose source/segment unloading.
+                LayerWeightsOwned {
+                    attn_norm: get_f32_tensor_from_source(
+                        source.as_ref(),
+                        &format!("blk.{}.attn_norm.weight", l),
+                        n_embd,
+                    ),
+                    ffn_norm: get_f32_tensor_from_source(
+                        source.as_ref(),
+                        &format!("blk.{}.ffn_norm.weight", l),
+                        n_embd,
+                    ),
+                    q_norm: if is_qwen3 {
+                        Some(get_f32_tensor_from_source(
+                            source.as_ref(),
+                            &format!("blk.{}.attn_q_norm.weight", l),
+                            n_embd_head_k,
+                        ))
+                    } else {
+                        None
+                    },
+                    k_norm: if is_qwen3 {
+                        Some(get_f32_tensor_from_source(
+                            source.as_ref(),
+                            &format!("blk.{}.attn_k_norm.weight", l),
+                            n_embd_head_k,
+                        ))
+                    } else {
+                        None
+                    },
+                    wq: std::mem::transmute::<&[u8], &'static [u8]>(
+                        source
                             .tensor_slice(&format!("blk.{}.attn_q.weight", l))
                             .unwrap(),
-                    )
-                },
-                wk: unsafe {
-                    std::mem::transmute::<&[u8], &'static [u8]>(
-                        loader
+                    ),
+                    wk: std::mem::transmute::<&[u8], &'static [u8]>(
+                        source
                             .tensor_slice(&format!("blk.{}.attn_k.weight", l))
                             .unwrap(),
-                    )
-                },
-                wv: unsafe {
-                    std::mem::transmute::<&[u8], &'static [u8]>(
-                        loader
+                    ),
+                    wv: std::mem::transmute::<&[u8], &'static [u8]>(
+                        source
                             .tensor_slice(&format!("blk.{}.attn_v.weight", l))
                             .unwrap(),
-                    )
-                },
-                wo: unsafe {
-                    std::mem::transmute::<&[u8], &'static [u8]>(
-                        loader
+                    ),
+                    wo: std::mem::transmute::<&[u8], &'static [u8]>(
+                        source
                             .tensor_slice(&format!("blk.{}.attn_output.weight", l))
                             .unwrap(),
-                    )
-                },
-                w_gate: unsafe {
-                    std::mem::transmute::<&[u8], &'static [u8]>(
-                        loader
+                    ),
+                    w_gate: std::mem::transmute::<&[u8], &'static [u8]>(
+                        source
                             .tensor_slice(&format!("blk.{}.ffn_gate.weight", l))
                             .unwrap(),
-                    )
-                },
-                w_up: unsafe {
-                    std::mem::transmute::<&[u8], &'static [u8]>(
-                        loader
+                    ),
+                    w_up: std::mem::transmute::<&[u8], &'static [u8]>(
+                        source
                             .tensor_slice(&format!("blk.{}.ffn_up.weight", l))
                             .unwrap(),
-                    )
-                },
-                w_down: unsafe {
-                    std::mem::transmute::<&[u8], &'static [u8]>(
-                        loader
+                    ),
+                    w_down: std::mem::transmute::<&[u8], &'static [u8]>(
+                        source
                             .tensor_slice(&format!("blk.{}.ffn_down.weight", l))
                             .unwrap(),
-                    )
-                },
+                    ),
+                }
             })
             .collect();
 
@@ -1138,6 +1140,7 @@ async fn main() {
         };
 
         ModelBackend::Qwen3(Qwen3State {
+            source: Arc::clone(&source),
             layers,
             output_norm,
             embd_weight,

--- a/RustModelInference/src/clip_config.rs
+++ b/RustModelInference/src/clip_config.rs
@@ -1,4 +1,4 @@
-use crate::model::{GGUFLoader, MetaValue};
+use crate::model::{MetaValue, TensorSource};
 
 #[derive(Debug, Clone)]
 pub struct ClipVisionConfig {
@@ -20,23 +20,23 @@ pub struct ClipVisionConfig {
 }
 
 impl ClipVisionConfig {
-    pub fn from_gguf(loader: &GGUFLoader) -> Result<Self, String> {
+    pub fn from_source<S: TensorSource + ?Sized>(source: &S) -> Result<Self, String> {
         let get_u32 = |key: &str| -> Result<u32, String> {
-            loader.metadata(key)
+            source.metadata(key)
                 .and_then(|v| v.to_u64())
                 .map(|v| v as u32)
                 .ok_or_else(|| format!("Missing clip metadata: {}", key))
         };
 
         let get_f32 = |key: &str| -> Result<f32, String> {
-            loader.metadata(key)
+            source.metadata(key)
                 .and_then(|v| v.to_f64())
                 .map(|v| v as f32)
                 .ok_or_else(|| format!("Missing clip metadata: {}", key))
         };
 
         let get_bool = |key: &str| -> bool {
-            loader.metadata(key)
+            source.metadata(key)
                 .and_then(|v| match v { MetaValue::Bool(b) => Some(*b), _ => None })
                 .unwrap_or(false)
         };
@@ -48,7 +48,7 @@ impl ClipVisionConfig {
         let n_ff = get_u32("clip.vision.feed_forward_length")? as usize;
         let n_layer = get_u32("clip.vision.block_count")? as usize;
         let n_head = get_u32("clip.vision.attention.head_count")? as usize;
-        let spatial_merge_size = loader.metadata("clip.vision.spatial_merge_size")
+        let spatial_merge_size = source.metadata("clip.vision.spatial_merge_size")
             .and_then(|v| v.to_u64())
             .map(usize::try_from)
             .transpose()
@@ -66,14 +66,14 @@ impl ClipVisionConfig {
         let default_max = factor_pixels
             .checked_mul(4096)
             .ok_or("clip maximum pixel count overflow")?;
-        let image_min_pixels = loader
+        let image_min_pixels = source
             .metadata("clip.vision.image_min_pixels")
             .and_then(MetaValue::to_u64)
             .map(usize::try_from)
             .transpose()
             .map_err(|_| "clip.vision.image_min_pixels does not fit usize")?
             .unwrap_or(default_min);
-        let image_max_pixels = loader
+        let image_max_pixels = source
             .metadata("clip.vision.image_max_pixels")
             .and_then(MetaValue::to_u64)
             .map(usize::try_from)
@@ -86,7 +86,7 @@ impl ClipVisionConfig {
         let eps = get_f32("clip.vision.attention.layer_norm_epsilon")?;
         let use_gelu = get_bool("clip.use_gelu");
 
-        let image_mean = match loader.metadata("clip.vision.image_mean") {
+        let image_mean = match source.metadata("clip.vision.image_mean") {
             Some(MetaValue::Array(_, vals)) => {
                 let m: Vec<f32> = vals.iter()
                     .filter_map(|v| v.to_f64().map(|x| x as f32))
@@ -102,7 +102,7 @@ impl ClipVisionConfig {
             }
         };
 
-        let image_std = match loader.metadata("clip.vision.image_std") {
+        let image_std = match source.metadata("clip.vision.image_std") {
             Some(MetaValue::Array(_, vals)) => {
                 let s: Vec<f32> = vals.iter()
                     .filter_map(|v| v.to_f64().map(|x| x as f32))
@@ -118,7 +118,7 @@ impl ClipVisionConfig {
             }
         };
 
-        let has_deepstack_layers = match loader.metadata("clip.vision.is_deepstack_layers") {
+        let has_deepstack_layers = match source.metadata("clip.vision.is_deepstack_layers") {
             Some(MetaValue::Array(_, vals)) => {
                 vals.iter()
                     .filter_map(|v| match v { MetaValue::Bool(b) => Some(*b), _ => None })
@@ -252,16 +252,16 @@ fn recurrent_layer_mask(
 }
 
 impl Qwen35Config {
-    pub fn from_gguf(loader: &GGUFLoader) -> Result<Self, String> {
+    pub fn from_source<S: TensorSource + ?Sized>(source: &S) -> Result<Self, String> {
         let get_u32 = |key: &str| -> Result<u32, String> {
-            loader.metadata(key)
+            source.metadata(key)
                 .and_then(|v| v.to_u64())
                 .map(|v| v as u32)
                 .ok_or_else(|| format!("Missing qwen35 metadata: {}", key))
         };
 
         let get_f32 = |key: &str| -> Result<f32, String> {
-            loader.metadata(key)
+            source.metadata(key)
                 .and_then(|v| v.to_f64())
                 .map(|v| v as f32)
                 .ok_or_else(|| format!("Missing qwen35 metadata: {}", key))
@@ -274,24 +274,24 @@ impl Qwen35Config {
         let n_ff = get_u32("qwen35.feed_forward_length")? as usize;
         let n_ctx = get_u32("qwen35.context_length")? as usize;
 
-        let key_length = loader.metadata("qwen35.attention.key_length").and_then(|v| v.to_u64()).unwrap_or(n_embd as u64 / n_head as u64) as usize;
-        let value_length = loader.metadata("qwen35.attention.value_length").and_then(|v| v.to_u64()).unwrap_or(n_embd as u64 / n_head as u64) as usize;
+        let key_length = source.metadata("qwen35.attention.key_length").and_then(|v| v.to_u64()).unwrap_or(n_embd as u64 / n_head as u64) as usize;
+        let value_length = source.metadata("qwen35.attention.value_length").and_then(|v| v.to_u64()).unwrap_or(n_embd as u64 / n_head as u64) as usize;
 
-        let vocab_size = match loader.metadata("tokenizer.ggml.tokens") {
+        let vocab_size = match source.metadata("tokenizer.ggml.tokens") {
             Some(MetaValue::Array(_, vals)) => vals.len(),
             _ => 151936,
         };
 
-        let rope_freq_base = loader.metadata("qwen35.rope.freq_base")
+        let rope_freq_base = source.metadata("qwen35.rope.freq_base")
             .and_then(|v| v.to_f64())
             .unwrap_or(1_000_000.0) as f32;
         let norm_eps = get_f32("qwen35.attention.layer_norm_rms_epsilon")?;
 
-        let rope_dimension_count = loader.metadata("qwen35.rope.dimension_count")
+        let rope_dimension_count = source.metadata("qwen35.rope.dimension_count")
             .and_then(|v| v.to_u64())
             .unwrap_or(64) as usize;
 
-        let rope_dimension_sections = match loader.metadata("qwen35.rope.dimension_sections") {
+        let rope_dimension_sections = match source.metadata("qwen35.rope.dimension_sections") {
             Some(MetaValue::Array(_, vals)) => {
                 let s: Vec<i32> = vals.iter()
                     .filter_map(|v| v.to_u64().map(|x| x as i32))
@@ -313,10 +313,10 @@ impl Qwen35Config {
         let ssm_dt_rank = get_u32("qwen35.ssm.time_step_rank")? as usize;
         let ssm_d_inner = get_u32("qwen35.ssm.inner_size")? as usize;
         let full_attention_interval_raw =
-            full_attention_interval(loader.metadata("qwen35.full_attention_interval"))?;
+            full_attention_interval(source.metadata("qwen35.full_attention_interval"))?;
         let is_recurrent = recurrent_layer_mask(
             n_layer,
-            loader.metadata("qwen35.attention.recurrent_layers"),
+            source.metadata("qwen35.attention.recurrent_layers"),
             full_attention_interval_raw,
         )?;
         let full_attention_interval = usize::try_from(full_attention_interval_raw.unwrap_or(4))
@@ -444,12 +444,16 @@ mod tests {
     #[ignore = "requires RMI_QWEN35_MODEL"]
     fn qwen35_config_uses_real_layer_selection_metadata() {
         let path = std::env::var("RMI_QWEN35_MODEL").unwrap();
-        let loader = crate::model::GGUFLoader::from_file(&path).unwrap();
-        let config = Qwen35Config::from_gguf(&loader).unwrap();
+        let source = crate::open_model_source(
+            std::path::Path::new(&path),
+            crate::ComponentRole::Llm,
+        )
+        .unwrap();
+        let config = Qwen35Config::from_source(source.as_ref()).unwrap();
         let expected = recurrent_layer_mask(
             config.n_layer,
-            loader.metadata("qwen35.attention.recurrent_layers"),
-            full_attention_interval(loader.metadata("qwen35.full_attention_interval")).unwrap(),
+            source.metadata("qwen35.attention.recurrent_layers"),
+            full_attention_interval(source.metadata("qwen35.full_attention_interval")).unwrap(),
         )
         .unwrap();
         assert_eq!(config.is_recurrent, expected);

--- a/RustModelInference/src/ggufrs.rs
+++ b/RustModelInference/src/ggufrs.rs
@@ -1934,8 +1934,28 @@ impl GgufrsFile {
             .filter(|segment| segment.id == id)
     }
 
+    pub(crate) fn segments_for_component(
+        &self,
+        component_id: u32,
+    ) -> impl Iterator<Item = &SegmentInfo> {
+        self.index
+            .segments
+            .iter()
+            .filter(move |segment| segment.component_id == component_id)
+    }
+
     pub(crate) fn tensors(&self) -> &[TensorRecord] {
         &self.index.tensors
+    }
+
+    pub(crate) fn tensors_for_segment(
+        &self,
+        segment_id: u32,
+    ) -> impl Iterator<Item = &TensorRecord> {
+        self.index
+            .tensors
+            .iter()
+            .filter(move |tensor| tensor.segment_id == segment_id)
     }
 
     #[allow(dead_code)]
@@ -3013,6 +3033,13 @@ pub(crate) mod test_support {
         pub(crate) mmproj_weight: Vec<u8>,
     }
 
+    pub(crate) struct LoadFixture {
+        pub(crate) package: GgufrsFile,
+        pub(crate) llm_component: u32,
+        #[allow(dead_code)]
+        pub(crate) inputs: TestInputs,
+    }
+
     impl Drop for TestInputs {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.dir);
@@ -3120,6 +3147,45 @@ pub(crate) mod test_support {
             llm_blk0,
             llm_blk1,
             mmproj_weight,
+        }
+    }
+
+    pub(crate) fn test_q8_row_package(rows: u64, row_elements: u64) -> LoadFixture {
+        let inputs = test_gguf_pair();
+        let row_bytes = (row_elements / 32) * 34;
+        write_test_gguf(
+            &inputs.llm,
+            &[
+                ("general.alignment".into(), MetaValue::Uint32(32)),
+                (
+                    "general.architecture".into(),
+                    MetaValue::String("qwen3".into()),
+                ),
+                ("qwen3.block_count".into(), MetaValue::Uint32(1)),
+            ],
+            &[
+                SourceTensor {
+                    name: "token_embd.weight",
+                    ggml_type: GGMLType::F32,
+                    dims: vec![32],
+                    bytes: vec![0x11; 128],
+                },
+                SourceTensor {
+                    name: "blk.0.weight",
+                    ggml_type: GGMLType::Q8_0,
+                    dims: vec![row_elements, rows],
+                    bytes: vec![0x22; (row_bytes * rows) as usize],
+                },
+            ],
+        );
+        let output = inputs.dir.join("q8-rows.ggufrs");
+        export_ggufrs(&output, &inputs.llm, None, ExportOptions::default()).unwrap();
+        let package = GgufrsFile::open(output).unwrap();
+        let llm_component = package.component_id(ComponentRole::Llm).unwrap();
+        LoadFixture {
+            package,
+            llm_component,
+            inputs,
         }
     }
 }

--- a/RustModelInference/src/ggufrs.rs
+++ b/RustModelInference/src/ggufrs.rs
@@ -1,0 +1,1897 @@
+use crate::model::{
+    ByteReader, GGMLType, GGUFLoader, MetaValue, MetaValueType, TensorInfo, TensorSource,
+};
+use memmap2::{Mmap, MmapOptions};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::fs::File;
+use std::io::{self, Read};
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+pub const GGUFRS_VERSION: u32 = 1;
+pub const GGUFRS_SEGMENT_ALIGNMENT: u64 = 64 * 1024;
+const GGUFRS_MAGIC: &[u8; 8] = b"GGUFRS\0\0";
+const SUPERBLOCK_LEN: usize = 128;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ComponentRole {
+    Llm = 1,
+    Mmproj = 2,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum SegmentKind {
+    Shared = 1,
+    Layer = 2,
+    Component = 3,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComponentInfo {
+    pub id: u32,
+    pub role: ComponentRole,
+    pub name: String,
+    pub metadata_range: Range<u32>,
+    pub tensor_range: Range<u32>,
+    pub segment_range: Range<u32>,
+}
+
+#[derive(Debug)]
+pub enum GgufrsError {
+    Io {
+        operation: &'static str,
+        path: PathBuf,
+        source: io::Error,
+    },
+    InvalidFormat {
+        context: String,
+    },
+    SourceGguf {
+        role: ComponentRole,
+        path: PathBuf,
+        message: String,
+    },
+    ChecksumMismatch {
+        component_id: u32,
+        segment_id: u32,
+        expected: [u8; 32],
+        actual: [u8; 32],
+    },
+    OutputExists {
+        path: PathBuf,
+    },
+    CapacityExceeded {
+        device_id: String,
+        required: u64,
+        available: u64,
+        context: String,
+    },
+    UnsplittableTensor {
+        component_id: u32,
+        tensor: String,
+        row_bytes: u64,
+        remaining: Vec<(String, u64)>,
+        reason: String,
+    },
+    InvalidPlan {
+        context: String,
+    },
+    UnsupportedPublish {
+        path: PathBuf,
+        operation: &'static str,
+        source: io::Error,
+    },
+}
+
+impl fmt::Display for GgufrsError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io {
+                operation,
+                path,
+                source,
+            } => write!(formatter, "{operation} {}: {source}", path.display()),
+            Self::InvalidFormat { context } => write!(formatter, "invalid ggufrs: {context}"),
+            Self::SourceGguf {
+                role,
+                path,
+                message,
+            } => write!(
+                formatter,
+                "failed to load source GGUF {:?} {}: {message}",
+                role,
+                path.display()
+            ),
+            Self::ChecksumMismatch {
+                component_id,
+                segment_id,
+                expected,
+                actual,
+            } => write!(
+                formatter,
+                "checksum mismatch for component {component_id} segment {segment_id}: expected {expected:02x?}, actual {actual:02x?}"
+            ),
+            Self::OutputExists { path } => {
+                write!(formatter, "output already exists: {}", path.display())
+            }
+            Self::CapacityExceeded {
+                device_id,
+                required,
+                available,
+                context,
+            } => write!(
+                formatter,
+                "device {device_id} capacity exceeded for {context}: required {required}, available {available}"
+            ),
+            Self::UnsplittableTensor {
+                component_id,
+                tensor,
+                row_bytes,
+                remaining,
+                reason,
+            } => write!(
+                formatter,
+                "component {component_id} tensor {tensor} cannot be split: row bytes {row_bytes}, remaining capacities {remaining:?}: {reason}"
+            ),
+            Self::InvalidPlan { context } => write!(formatter, "invalid ggufrs plan: {context}"),
+            Self::UnsupportedPublish {
+                path,
+                operation,
+                source,
+            } => write!(
+                formatter,
+                "unsupported publish operation {operation} for {}: {source}",
+                path.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for GgufrsError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io { source, .. } | Self::UnsupportedPublish { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TableRange {
+    offset: u64,
+    length: u64,
+}
+
+#[derive(Debug)]
+struct Superblock {
+    declared_file_size: u64,
+    component_count: u32,
+    metadata_count: u32,
+    segment_count: u32,
+    tensor_count: u32,
+    component_table: TableRange,
+    metadata_table: TableRange,
+    segment_table: TableRange,
+    tensor_table: TableRange,
+    tensor_data_offset: u64,
+}
+
+#[derive(Debug, Clone)]
+struct ScopedMetadata {
+    component_id: u32,
+    key: String,
+    value: MetaValue,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SegmentInfo {
+    pub id: u32,
+    pub component_id: u32,
+    pub kind: SegmentKind,
+    pub layer: Option<u32>,
+    pub absolute_offset: u64,
+    pub stored_len: u64,
+    pub tensor_range: Range<u32>,
+    pub sha256: [u8; 32],
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TensorRecord {
+    pub component_id: u32,
+    pub segment_id: u32,
+    pub info: TensorInfo,
+    pub segment_offset: u64,
+    pub byte_len: u64,
+}
+
+#[derive(Debug)]
+struct PackageIndex {
+    components: Vec<ComponentInfo>,
+    metadata: Vec<ScopedMetadata>,
+    segments: Vec<SegmentInfo>,
+    tensors: Vec<TensorRecord>,
+    component_by_role: BTreeMap<ComponentRole, u32>,
+    metadata_lookup: BTreeMap<(u32, String), usize>,
+    tensor_lookup: BTreeMap<(u32, String), usize>,
+}
+
+#[derive(Clone)]
+pub struct GgufrsFile {
+    file: Arc<File>,
+    path: Arc<PathBuf>,
+    index: Arc<PackageIndex>,
+}
+
+pub struct LoadedComponent {
+    file: Arc<File>,
+    path: Arc<PathBuf>,
+    index: Arc<PackageIndex>,
+    component_id: u32,
+    mappings: BTreeMap<u32, Arc<MappedSegment>>,
+    tensor_infos: BTreeMap<String, TensorInfo>,
+}
+
+pub(crate) struct MappedSegment {
+    pub segment_id: u32,
+    pub bytes: Mmap,
+}
+
+fn invalid(context: impl Into<String>) -> GgufrsError {
+    GgufrsError::InvalidFormat {
+        context: context.into(),
+    }
+}
+
+fn checked_range(
+    offset: u64,
+    len: u64,
+    file_len: u64,
+    context: &str,
+) -> Result<Range<usize>, GgufrsError> {
+    let end = offset
+        .checked_add(len)
+        .ok_or_else(|| invalid(format!("{context} range overflow")))?;
+    if end > file_len {
+        return Err(invalid(format!(
+            "{context} range {offset}..{end} exceeds file length {file_len}"
+        )));
+    }
+    Ok(usize::try_from(offset)
+        .map_err(|_| invalid(format!("{context} offset does not fit usize")))?
+        ..usize::try_from(end).map_err(|_| invalid(format!("{context} end does not fit usize")))?)
+}
+
+fn counted_range(start: u32, count: u32, context: &str) -> Result<Range<u32>, GgufrsError> {
+    Ok(start
+        ..start
+            .checked_add(count)
+            .ok_or_else(|| invalid(format!("{context} count overflow")))?)
+}
+
+fn component_role(value: u32) -> Result<ComponentRole, GgufrsError> {
+    match value {
+        1 => Ok(ComponentRole::Llm),
+        2 => Ok(ComponentRole::Mmproj),
+        _ => Err(invalid(format!("unknown component role {value}"))),
+    }
+}
+
+fn segment_kind(value: u32) -> Result<SegmentKind, GgufrsError> {
+    match value {
+        1 => Ok(SegmentKind::Shared),
+        2 => Ok(SegmentKind::Layer),
+        3 => Ok(SegmentKind::Component),
+        _ => Err(invalid(format!("unknown segment kind {value}"))),
+    }
+}
+
+fn read_superblock(bytes: &[u8]) -> Result<Superblock, GgufrsError> {
+    let header = bytes
+        .get(..SUPERBLOCK_LEN)
+        .ok_or_else(|| invalid("file is shorter than the 128-byte superblock"))?;
+    let mut reader = ByteReader::new(header);
+    if reader.read_exact(8, "ggufrs magic").map_err(invalid)? != GGUFRS_MAGIC {
+        return Err(invalid("invalid ggufrs magic"));
+    }
+    let version = reader.read_u32().map_err(invalid)?;
+    let flags = reader.read_u32().map_err(invalid)?;
+    if version != GGUFRS_VERSION || flags != 0 {
+        return Err(invalid(format!(
+            "unsupported ggufrs version/flags: version={version}, flags={flags}"
+        )));
+    }
+    let declared_file_size = reader.read_u64().map_err(invalid)?;
+    let component_count = reader.read_u32().map_err(invalid)?;
+    let metadata_count = reader.read_u32().map_err(invalid)?;
+    let segment_count = reader.read_u32().map_err(invalid)?;
+    let tensor_count = reader.read_u32().map_err(invalid)?;
+    let mut table = || -> Result<TableRange, GgufrsError> {
+        Ok(TableRange {
+            offset: reader.read_u64().map_err(invalid)?,
+            length: reader.read_u64().map_err(invalid)?,
+        })
+    };
+    let component_table = table()?;
+    let metadata_table = table()?;
+    let segment_table = table()?;
+    let tensor_table = table()?;
+    let tensor_data_offset = reader.read_u64().map_err(invalid)?;
+    if reader
+        .read_exact(16, "reserved superblock bytes")
+        .map_err(invalid)?
+        != [0u8; 16]
+    {
+        return Err(invalid("reserved superblock bytes must be zero"));
+    }
+    Ok(Superblock {
+        declared_file_size,
+        component_count,
+        metadata_count,
+        segment_count,
+        tensor_count,
+        component_table,
+        metadata_table,
+        segment_table,
+        tensor_table,
+        tensor_data_offset,
+    })
+}
+
+fn validate_table_layout(superblock: &Superblock, bytes: &[u8]) -> Result<(), GgufrsError> {
+    let file_len = u64::try_from(bytes.len()).map_err(|_| invalid("file length exceeds u64"))?;
+    if superblock.declared_file_size != file_len {
+        return Err(invalid(format!(
+            "declared file size {} does not match actual file size {file_len}",
+            superblock.declared_file_size
+        )));
+    }
+    if superblock.tensor_data_offset % GGUFRS_SEGMENT_ALIGNMENT != 0 {
+        return Err(invalid(format!(
+            "tensor data offset {} is not aligned to {GGUFRS_SEGMENT_ALIGNMENT}",
+            superblock.tensor_data_offset
+        )));
+    }
+
+    let tables = [
+        ("component table", superblock.component_table),
+        ("metadata table", superblock.metadata_table),
+        ("segment table", superblock.segment_table),
+        ("tensor table", superblock.tensor_table),
+    ];
+    let mut expected_offset = SUPERBLOCK_LEN as u64;
+    for (name, table) in tables {
+        checked_range(table.offset, table.length, file_len, name)?;
+        if table.offset != expected_offset {
+            return Err(invalid(format!(
+                "{name} begins at {}, expected contiguous offset {expected_offset}",
+                table.offset
+            )));
+        }
+        expected_offset = table
+            .offset
+            .checked_add(table.length)
+            .ok_or_else(|| invalid(format!("{name} range overflow")))?;
+    }
+    if expected_offset > superblock.tensor_data_offset {
+        return Err(invalid(format!(
+            "tensor table ends at {expected_offset}, after tensor data offset {}",
+            superblock.tensor_data_offset
+        )));
+    }
+    let padding = checked_range(
+        expected_offset,
+        superblock.tensor_data_offset - expected_offset,
+        file_len,
+        "index padding",
+    )?;
+    if bytes[padding].iter().any(|byte| *byte != 0) {
+        return Err(invalid("index padding before tensor data must be zero"));
+    }
+    Ok(())
+}
+
+fn table_bytes<'a>(
+    bytes: &'a [u8],
+    table: TableRange,
+    context: &str,
+) -> Result<&'a [u8], GgufrsError> {
+    let file_len = u64::try_from(bytes.len()).map_err(|_| invalid("file length exceeds u64"))?;
+    Ok(&bytes[checked_range(table.offset, table.length, file_len, context)?])
+}
+
+fn parse_index(superblock: &Superblock, bytes: &[u8]) -> Result<PackageIndex, GgufrsError> {
+    validate_table_layout(superblock, bytes)?;
+
+    let component_bytes = table_bytes(bytes, superblock.component_table, "component table")?;
+    let mut reader = ByteReader::new(component_bytes);
+    let mut components = Vec::new();
+    for entry in 0..superblock.component_count {
+        let context = format!("component {entry}");
+        let id = reader
+            .read_u32()
+            .map_err(|message| invalid(format!("{context}: {message}")))?;
+        let role = component_role(
+            reader
+                .read_u32()
+                .map_err(|message| invalid(format!("{context}: {message}")))?,
+        )?;
+        let name = reader
+            .read_string()
+            .map_err(|message| invalid(format!("{context}: {message}")))?;
+        let metadata_start = reader
+            .read_u32()
+            .map_err(|message| invalid(format!("{context}: {message}")))?;
+        let metadata_count = reader
+            .read_u32()
+            .map_err(|message| invalid(format!("{context}: {message}")))?;
+        let tensor_start = reader
+            .read_u32()
+            .map_err(|message| invalid(format!("{context}: {message}")))?;
+        let tensor_count = reader
+            .read_u32()
+            .map_err(|message| invalid(format!("{context}: {message}")))?;
+        let segment_start = reader
+            .read_u32()
+            .map_err(|message| invalid(format!("{context}: {message}")))?;
+        let segment_count = reader
+            .read_u32()
+            .map_err(|message| invalid(format!("{context}: {message}")))?;
+        components.push(ComponentInfo {
+            id,
+            role,
+            name,
+            metadata_range: counted_range(metadata_start, metadata_count, &context)?,
+            tensor_range: counted_range(tensor_start, tensor_count, &context)?,
+            segment_range: counted_range(segment_start, segment_count, &context)?,
+        });
+    }
+    if reader.pos() != component_bytes.len() {
+        return Err(invalid(format!(
+            "component table has {} trailing bytes",
+            component_bytes.len() - reader.pos()
+        )));
+    }
+
+    let metadata_bytes = table_bytes(bytes, superblock.metadata_table, "metadata table")?;
+    let mut reader = ByteReader::new(metadata_bytes);
+    let mut metadata = Vec::new();
+    for entry in 0..superblock.metadata_count {
+        let context = format!("metadata {entry}");
+        let component_id = reader
+            .read_u32()
+            .map_err(|message| invalid(format!("{context}: {message}")))?;
+        let key = reader
+            .read_string()
+            .map_err(|message| invalid(format!("{context}: {message}")))?;
+        let value_type_raw = reader
+            .read_i32()
+            .map_err(|message| invalid(format!("{context} key {key}: {message}")))?;
+        let value_type = MetaValueType::from_i32(value_type_raw).ok_or_else(|| {
+            invalid(format!(
+                "{context} key {key}: unknown metadata value type {value_type_raw}"
+            ))
+        })?;
+        let value = reader
+            .read_meta_value(value_type)
+            .map_err(|message| invalid(format!("{context} key {key}: {message}")))?;
+        metadata.push(ScopedMetadata {
+            component_id,
+            key,
+            value,
+        });
+    }
+    if reader.pos() != metadata_bytes.len() {
+        return Err(invalid(format!(
+            "metadata table has {} trailing bytes",
+            metadata_bytes.len() - reader.pos()
+        )));
+    }
+
+    let segment_bytes = table_bytes(bytes, superblock.segment_table, "segment table")?;
+    let mut reader = ByteReader::new(segment_bytes);
+    let mut segments = Vec::new();
+    for entry in 0..superblock.segment_count {
+        let context = format!("segment {entry}");
+        let id = reader
+            .read_u32()
+            .map_err(|message| invalid(format!("{context}: {message}")))?;
+        let component_id = reader
+            .read_u32()
+            .map_err(|message| invalid(format!("{context}: {message}")))?;
+        let kind = segment_kind(
+            reader
+                .read_u32()
+                .map_err(|message| invalid(format!("{context}: {message}")))?,
+        )?;
+        let layer_raw = reader
+            .read_i32()
+            .map_err(|message| invalid(format!("{context}: {message}")))?;
+        let layer = match layer_raw {
+            -1 => None,
+            value if value >= 0 => Some(value as u32),
+            _ => {
+                return Err(invalid(format!(
+                    "{context}: invalid layer value {layer_raw}"
+                )))
+            }
+        };
+        let absolute_offset = reader
+            .read_u64()
+            .map_err(|message| invalid(format!("{context}: {message}")))?;
+        let stored_len = reader
+            .read_u64()
+            .map_err(|message| invalid(format!("{context}: {message}")))?;
+        let tensor_start = reader
+            .read_u32()
+            .map_err(|message| invalid(format!("{context}: {message}")))?;
+        let tensor_count = reader
+            .read_u32()
+            .map_err(|message| invalid(format!("{context}: {message}")))?;
+        let mut sha256 = [0u8; 32];
+        sha256.copy_from_slice(
+            reader
+                .read_exact(32, "segment sha256")
+                .map_err(|message| invalid(format!("{context}: {message}")))?,
+        );
+        segments.push(SegmentInfo {
+            id,
+            component_id,
+            kind,
+            layer,
+            absolute_offset,
+            stored_len,
+            tensor_range: counted_range(tensor_start, tensor_count, &context)?,
+            sha256,
+        });
+    }
+    if reader.pos() != segment_bytes.len() {
+        return Err(invalid(format!(
+            "segment table has {} trailing bytes",
+            segment_bytes.len() - reader.pos()
+        )));
+    }
+
+    let tensor_bytes = table_bytes(bytes, superblock.tensor_table, "tensor table")?;
+    let mut reader = ByteReader::new(tensor_bytes);
+    let mut tensors = Vec::new();
+    for entry in 0..superblock.tensor_count {
+        let context = format!("tensor {entry}");
+        let component_id = reader
+            .read_u32()
+            .map_err(|message| invalid(format!("{context}: {message}")))?;
+        let segment_id = reader
+            .read_u32()
+            .map_err(|message| invalid(format!("{context}: {message}")))?;
+        let name = reader
+            .read_string()
+            .map_err(|message| invalid(format!("{context}: {message}")))?;
+        let tensor_context = format!("component {component_id} segment {segment_id} tensor {name}");
+        let type_raw = reader
+            .read_i32()
+            .map_err(|message| invalid(format!("{tensor_context}: {message}")))?;
+        let ggml_type = GGMLType::from_i32(type_raw)
+            .ok_or_else(|| invalid(format!("{tensor_context}: unknown GGML type {type_raw}")))?;
+        let rank = reader
+            .read_u32()
+            .map_err(|message| invalid(format!("{tensor_context}: {message}")))?;
+        let mut dims = Vec::new();
+        for _ in 0..rank {
+            dims.push(
+                reader
+                    .read_u64()
+                    .map_err(|message| invalid(format!("{tensor_context}: {message}")))?,
+            );
+        }
+        let segment_offset = reader
+            .read_u64()
+            .map_err(|message| invalid(format!("{tensor_context}: {message}")))?;
+        let byte_len = reader
+            .read_u64()
+            .map_err(|message| invalid(format!("{tensor_context}: {message}")))?;
+        tensors.push(TensorRecord {
+            component_id,
+            segment_id,
+            info: TensorInfo {
+                name,
+                dims,
+                ggml_type,
+                offset: segment_offset,
+            },
+            segment_offset,
+            byte_len,
+        });
+    }
+    if reader.pos() != tensor_bytes.len() {
+        return Err(invalid(format!(
+            "tensor table has {} trailing bytes",
+            tensor_bytes.len() - reader.pos()
+        )));
+    }
+
+    let mut index = PackageIndex {
+        components,
+        metadata,
+        segments,
+        tensors,
+        component_by_role: BTreeMap::new(),
+        metadata_lookup: BTreeMap::new(),
+        tensor_lookup: BTreeMap::new(),
+    };
+    validate_index(superblock, bytes, &mut index)?;
+    Ok(index)
+}
+
+fn range_end_within(range: &Range<u32>, len: usize, context: &str) -> Result<(), GgufrsError> {
+    if u64::from(range.end) > len as u64 {
+        return Err(invalid(format!(
+            "{context} range {}..{} exceeds table count {len}",
+            range.start, range.end
+        )));
+    }
+    Ok(())
+}
+
+fn metadata_value<'a>(
+    index: &'a PackageIndex,
+    component_id: u32,
+    key: &str,
+) -> Option<&'a MetaValue> {
+    index
+        .metadata
+        .iter()
+        .find(|entry| entry.component_id == component_id && entry.key == key)
+        .map(|entry| &entry.value)
+}
+
+fn validate_index(
+    superblock: &Superblock,
+    _file_bytes: &[u8],
+    index: &mut PackageIndex,
+) -> Result<(), GgufrsError> {
+    let mut roles = BTreeSet::new();
+    let mut next_metadata = 0u32;
+    let mut next_tensor = 0u32;
+    let mut next_segment = 0u32;
+    let mut previous_component: Option<&ComponentInfo> = None;
+
+    for (position, component) in index.components.iter().enumerate() {
+        let context = format!(
+            "component {} ({:?} {})",
+            component.id, component.role, component.name
+        );
+        if component.id != position as u32 {
+            return Err(invalid(format!(
+                "{context}: id is {}, expected {position}",
+                component.id
+            )));
+        }
+        if let Some(previous) = previous_component {
+            if (previous.role, previous.name.as_bytes())
+                >= (component.role, component.name.as_bytes())
+            {
+                return Err(invalid(format!(
+                    "{context}: components are not sorted by role and UTF-8 name bytes"
+                )));
+            }
+        }
+        previous_component = Some(component);
+        if !roles.insert(component.role) {
+            return Err(invalid(format!("{context}: duplicate component role")));
+        }
+
+        for (label, range, expected, len) in [
+            (
+                "metadata",
+                &component.metadata_range,
+                &mut next_metadata,
+                index.metadata.len(),
+            ),
+            (
+                "tensor",
+                &component.tensor_range,
+                &mut next_tensor,
+                index.tensors.len(),
+            ),
+            (
+                "segment",
+                &component.segment_range,
+                &mut next_segment,
+                index.segments.len(),
+            ),
+        ] {
+            range_end_within(range, len, &format!("{context} {label}"))?;
+            if range.start != *expected {
+                return Err(invalid(format!(
+                    "{context}: {label} range begins at {}, expected exclusive coverage from {}",
+                    range.start, *expected
+                )));
+            }
+            *expected = range.end;
+        }
+
+        let mut previous_key: Option<&[u8]> = None;
+        let mut metadata_keys = BTreeSet::new();
+        for metadata_position in component.metadata_range.clone() {
+            let entry = &index.metadata[metadata_position as usize];
+            if entry.component_id != component.id {
+                return Err(invalid(format!(
+                    "{context}: metadata {metadata_position} belongs to component {}",
+                    entry.component_id
+                )));
+            }
+            if !metadata_keys.insert(entry.key.as_str()) {
+                return Err(invalid(format!(
+                    "{context}: duplicate metadata key {}",
+                    entry.key
+                )));
+            }
+            if let Some(previous) = previous_key {
+                match previous.cmp(entry.key.as_bytes()) {
+                    std::cmp::Ordering::Equal => unreachable!("duplicate checked above"),
+                    std::cmp::Ordering::Greater => {
+                        return Err(invalid(format!(
+                            "{context}: metadata keys are not sorted at {}",
+                            entry.key
+                        )))
+                    }
+                    std::cmp::Ordering::Less => {}
+                }
+            }
+            previous_key = Some(entry.key.as_bytes());
+        }
+
+        let mut tensor_names = BTreeSet::new();
+        for tensor_position in component.tensor_range.clone() {
+            let tensor = &index.tensors[tensor_position as usize];
+            if tensor.component_id != component.id {
+                return Err(invalid(format!(
+                    "{context}: tensor {} belongs to component {}",
+                    tensor.info.name, tensor.component_id
+                )));
+            }
+            if !tensor_names.insert(tensor.info.name.as_str()) {
+                return Err(invalid(format!(
+                    "{context}: duplicate tensor name {}",
+                    tensor.info.name
+                )));
+            }
+        }
+
+        for segment_position in component.segment_range.clone() {
+            let segment = &index.segments[segment_position as usize];
+            if segment.component_id != component.id {
+                return Err(invalid(format!(
+                    "{context}: segment {} belongs to component {}",
+                    segment.id, segment.component_id
+                )));
+            }
+        }
+    }
+
+    if next_metadata != superblock.metadata_count
+        || next_tensor != superblock.tensor_count
+        || next_segment != superblock.segment_count
+    {
+        return Err(invalid(format!(
+            "component ranges do not cover all tables: metadata {next_metadata}/{}, tensors {next_tensor}/{}, segments {next_segment}/{}",
+            superblock.metadata_count,
+            superblock.tensor_count,
+            superblock.segment_count
+        )));
+    }
+    if index
+        .components
+        .iter()
+        .filter(|component| component.role == ComponentRole::Llm)
+        .count()
+        != 1
+    {
+        return Err(invalid("package must contain exactly one LLM component"));
+    }
+    if index
+        .components
+        .iter()
+        .filter(|component| component.role == ComponentRole::Mmproj)
+        .count()
+        > 1
+    {
+        return Err(invalid("package may contain at most one mmproj component"));
+    }
+
+    let mut expected_segment_offset = superblock.tensor_data_offset;
+    for (position, segment) in index.segments.iter().enumerate() {
+        let context = format!("component {} segment {}", segment.component_id, segment.id);
+        if segment.id != position as u32 {
+            return Err(invalid(format!(
+                "{context}: segment id is {}, expected {position}",
+                segment.id
+            )));
+        }
+        if segment.absolute_offset == 0 || segment.stored_len == 0 {
+            return Err(invalid(format!(
+                "{context}: segment offset and length must be nonzero"
+            )));
+        }
+        if segment.absolute_offset % GGUFRS_SEGMENT_ALIGNMENT != 0
+            || segment.stored_len % GGUFRS_SEGMENT_ALIGNMENT != 0
+        {
+            return Err(invalid(format!(
+                "{context}: segment offset {} and length {} must be aligned to {GGUFRS_SEGMENT_ALIGNMENT}",
+                segment.absolute_offset, segment.stored_len
+            )));
+        }
+        if segment.absolute_offset < superblock.tensor_data_offset {
+            return Err(invalid(format!(
+                "{context}: offset {} is before tensor data offset {}",
+                segment.absolute_offset, superblock.tensor_data_offset
+            )));
+        }
+        let end = segment
+            .absolute_offset
+            .checked_add(segment.stored_len)
+            .ok_or_else(|| invalid(format!("{context}: segment range overflow")))?;
+        if end > superblock.declared_file_size {
+            return Err(invalid(format!(
+                "{context}: segment end {end} exceeds declared file size {}",
+                superblock.declared_file_size
+            )));
+        }
+        if segment.absolute_offset != expected_segment_offset {
+            let relation = if segment.absolute_offset < expected_segment_offset {
+                "overlaps the previous segment"
+            } else {
+                "is not contiguous with the previous segment"
+            };
+            return Err(invalid(format!(
+                "{context}: offset {} {relation}; expected {expected_segment_offset}",
+                segment.absolute_offset
+            )));
+        }
+        expected_segment_offset = end;
+    }
+    if expected_segment_offset != superblock.declared_file_size {
+        return Err(invalid(format!(
+            "last segment ends at {expected_segment_offset}, expected declared file size {}",
+            superblock.declared_file_size
+        )));
+    }
+
+    for component in &index.components {
+        let context = format!(
+            "component {} ({:?} {})",
+            component.id, component.role, component.name
+        );
+        let alignment = metadata_value(index, component.id, "general.alignment")
+            .map(|value| {
+                value.to_u64().ok_or_else(|| {
+                    invalid(format!("{context}: general.alignment is not an integer"))
+                })
+            })
+            .transpose()?
+            .unwrap_or(32);
+        if alignment == 0 || !alignment.is_power_of_two() {
+            return Err(invalid(format!(
+                "{context}: general.alignment {alignment} is not a nonzero power of two"
+            )));
+        }
+        let tensor_alignment = alignment.max(32);
+        let mut next_component_tensor = component.tensor_range.start;
+        let mut previous_segment_key: Option<(u32, u32)> = None;
+        let mut layer_indices = BTreeSet::new();
+        let mut shared_count = 0usize;
+        let mut component_segment_count = 0usize;
+
+        for segment_position in component.segment_range.clone() {
+            let segment = &index.segments[segment_position as usize];
+            range_end_within(
+                &segment.tensor_range,
+                index.tensors.len(),
+                &format!("{context} segment {} tensor", segment.id),
+            )?;
+            if segment.tensor_range.start != next_component_tensor
+                || segment.tensor_range.end > component.tensor_range.end
+            {
+                return Err(invalid(format!(
+                    "{context} segment {} tensor range {}..{} does not exclusively cover component tensor range from {next_component_tensor}",
+                    segment.id, segment.tensor_range.start, segment.tensor_range.end
+                )));
+            }
+            next_component_tensor = segment.tensor_range.end;
+
+            match (component.role, segment.kind) {
+                (ComponentRole::Llm, SegmentKind::Shared) => shared_count += 1,
+                (ComponentRole::Llm, SegmentKind::Layer) => {}
+                (ComponentRole::Mmproj, SegmentKind::Component) => component_segment_count += 1,
+                _ => {
+                    return Err(invalid(format!(
+                        "{context} segment {}: {:?} kind is invalid for {:?}",
+                        segment.id, segment.kind, component.role
+                    )))
+                }
+            }
+            match (segment.kind, segment.layer) {
+                (SegmentKind::Layer, Some(layer)) => {
+                    if !layer_indices.insert(layer) {
+                        return Err(invalid(format!(
+                            "{context} segment {}: duplicate layer index {layer}",
+                            segment.id
+                        )));
+                    }
+                }
+                (SegmentKind::Layer, None) => {
+                    return Err(invalid(format!(
+                        "{context} segment {}: layer segment lacks a nonnegative layer index",
+                        segment.id
+                    )))
+                }
+                (_, Some(layer)) => {
+                    return Err(invalid(format!(
+                        "{context} segment {}: non-layer segment has layer index {layer}",
+                        segment.id
+                    )))
+                }
+                (_, None) => {}
+            }
+
+            let segment_key = (segment.kind as u32, segment.layer.unwrap_or(0));
+            if previous_segment_key.is_some_and(|previous| previous >= segment_key) {
+                return Err(invalid(format!(
+                    "{context} segment {}: segment kind/layer order is noncanonical",
+                    segment.id
+                )));
+            }
+            previous_segment_key = Some(segment_key);
+
+            let mut previous_tensor_name: Option<&[u8]> = None;
+            let mut tensor_ranges = Vec::new();
+            for tensor_position in segment.tensor_range.clone() {
+                let tensor = &index.tensors[tensor_position as usize];
+                let tensor_context = format!(
+                    "component {} segment {} tensor {}",
+                    component.id, segment.id, tensor.info.name
+                );
+                if tensor.component_id != component.id || tensor.segment_id != segment.id {
+                    return Err(invalid(format!(
+                        "{tensor_context}: references component {} segment {}",
+                        tensor.component_id, tensor.segment_id
+                    )));
+                }
+                if let Some(previous) = previous_tensor_name {
+                    if previous >= tensor.info.name.as_bytes() {
+                        return Err(invalid(format!(
+                            "{tensor_context}: tensor names are not byte-sorted inside segment"
+                        )));
+                    }
+                }
+                previous_tensor_name = Some(tensor.info.name.as_bytes());
+
+                if tensor.info.dims.is_empty() {
+                    return Err(invalid(format!("{tensor_context}: tensor rank is zero")));
+                }
+                tensor.info.checked_n_elements().ok_or_else(|| {
+                    invalid(format!("{tensor_context}: tensor dimensions overflow"))
+                })?;
+                let expected_len = tensor.info.checked_nbytes().ok_or_else(|| {
+                    invalid(format!(
+                        "{tensor_context}: tensor dimensions/type do not form complete GGML blocks"
+                    ))
+                })?;
+                if tensor.byte_len != expected_len {
+                    return Err(invalid(format!(
+                        "{tensor_context}: byte length {} differs from checked size {expected_len}",
+                        tensor.byte_len
+                    )));
+                }
+
+                if tensor.segment_offset % tensor_alignment != 0 {
+                    return Err(invalid(format!(
+                        "{tensor_context}: segment offset {} is not aligned to {tensor_alignment}",
+                        tensor.segment_offset
+                    )));
+                }
+                let tensor_end = tensor
+                    .segment_offset
+                    .checked_add(tensor.byte_len)
+                    .ok_or_else(|| invalid(format!("{tensor_context}: tensor range overflow")))?;
+                if tensor_end > segment.stored_len {
+                    return Err(invalid(format!(
+                        "{tensor_context}: range {}..{tensor_end} exceeds segment length {}",
+                        tensor.segment_offset, segment.stored_len
+                    )));
+                }
+                tensor_ranges.push((tensor.segment_offset, tensor_end, tensor.info.name.as_str()));
+            }
+            tensor_ranges.sort_unstable_by_key(|range| (range.0, range.1));
+            for pair in tensor_ranges.windows(2) {
+                if pair[1].0 < pair[0].1 {
+                    return Err(invalid(format!(
+                        "{context} segment {}: tensors {} and {} overlap",
+                        segment.id, pair[0].2, pair[1].2
+                    )));
+                }
+            }
+        }
+        if next_component_tensor != component.tensor_range.end {
+            return Err(invalid(format!(
+                "{context}: segment tensor ranges end at {next_component_tensor}, expected {}",
+                component.tensor_range.end
+            )));
+        }
+
+        match component.role {
+            ComponentRole::Llm => {
+                if shared_count != 1 {
+                    return Err(invalid(format!(
+                        "{context}: LLM must have exactly one shared segment"
+                    )));
+                }
+                let architecture = metadata_value(index, component.id, "general.architecture")
+                    .and_then(MetaValue::to_string_val)
+                    .ok_or_else(|| {
+                        invalid(format!(
+                            "{context}: missing or invalid general.architecture"
+                        ))
+                    })?;
+                let block_key = format!("{architecture}.block_count");
+                let block_count = metadata_value(index, component.id, &block_key)
+                    .and_then(MetaValue::to_u64)
+                    .and_then(|value| u32::try_from(value).ok())
+                    .ok_or_else(|| invalid(format!("{context}: missing or invalid {block_key}")))?;
+                if layer_indices.len() != block_count as usize
+                    || !layer_indices.iter().copied().eq(0..block_count)
+                {
+                    return Err(invalid(format!(
+                        "{context}: layer indices must be exactly 0..{block_count}, got {layer_indices:?}"
+                    )));
+                }
+            }
+            ComponentRole::Mmproj => {
+                if component_segment_count != 1 || component.segment_range.len() != 1 {
+                    return Err(invalid(format!(
+                        "{context}: mmproj must have exactly one component segment"
+                    )));
+                }
+            }
+        }
+    }
+
+    for component in &index.components {
+        index.component_by_role.insert(component.role, component.id);
+    }
+    for (position, entry) in index.metadata.iter().enumerate() {
+        index
+            .metadata_lookup
+            .insert((entry.component_id, entry.key.clone()), position);
+    }
+    for (position, tensor) in index.tensors.iter().enumerate() {
+        index
+            .tensor_lookup
+            .insert((tensor.component_id, tensor.info.name.clone()), position);
+    }
+    Ok(())
+}
+
+impl GgufrsFile {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, GgufrsError> {
+        let path = path.as_ref().to_path_buf();
+        let file = File::open(&path).map_err(|source| GgufrsError::Io {
+            operation: "open ggufrs",
+            path: path.clone(),
+            source,
+        })?;
+        let file_len = file
+            .metadata()
+            .map_err(|source| GgufrsError::Io {
+                operation: "read ggufrs metadata",
+                path: path.clone(),
+                source,
+            })?
+            .len();
+        if file_len < SUPERBLOCK_LEN as u64 {
+            return Err(invalid("file is shorter than the 128-byte superblock"));
+        }
+        let bytes = unsafe { MmapOptions::new().map(&file) }.map_err(|source| GgufrsError::Io {
+            operation: "map ggufrs index",
+            path: path.clone(),
+            source,
+        })?;
+        let superblock = read_superblock(&bytes)?;
+        let index = parse_index(&superblock, &bytes)?;
+        Ok(Self {
+            file: Arc::new(file),
+            path: Arc::new(path),
+            index: Arc::new(index),
+        })
+    }
+
+    pub fn components(&self) -> &[ComponentInfo] {
+        &self.index.components
+    }
+
+    pub fn component_id(&self, role: ComponentRole) -> Option<u32> {
+        self.index.component_by_role.get(&role).copied()
+    }
+
+    pub fn load_component(&self, role: ComponentRole) -> Result<LoadedComponent, GgufrsError> {
+        let component_id = self
+            .component_id(role)
+            .ok_or_else(|| invalid(format!("package has no {role:?} component")))?;
+        self.load_component_id(component_id)
+    }
+
+    pub fn load_component_id(&self, component_id: u32) -> Result<LoadedComponent, GgufrsError> {
+        let component = self
+            .index
+            .components
+            .get(component_id as usize)
+            .filter(|component| component.id == component_id)
+            .ok_or_else(|| invalid(format!("unknown component id {component_id}")))?;
+        let mut mappings = BTreeMap::new();
+        for segment_id in component.segment_range.clone() {
+            mappings.insert(segment_id, self.map_segment_shared(segment_id)?);
+        }
+        let tensor_infos = component
+            .tensor_range
+            .clone()
+            .map(|position| {
+                let info = self.tensors()[position as usize].info.clone();
+                (info.name.clone(), info)
+            })
+            .collect();
+        Ok(LoadedComponent {
+            file: Arc::clone(&self.file),
+            path: Arc::clone(&self.path),
+            index: Arc::clone(&self.index),
+            component_id,
+            mappings,
+            tensor_infos,
+        })
+    }
+
+    pub fn verify_all(&self) -> Result<(), GgufrsError> {
+        for component in &self.index.components {
+            drop(self.load_component_id(component.id)?);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn segment(&self, id: u32) -> Option<&SegmentInfo> {
+        self.index
+            .segments
+            .get(id as usize)
+            .filter(|segment| segment.id == id)
+    }
+
+    pub(crate) fn tensors(&self) -> &[TensorRecord] {
+        &self.index.tensors
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn layer_segment_id(&self, component_id: u32, layer: u32) -> Option<u32> {
+        self.index
+            .segments
+            .iter()
+            .find(|segment| {
+                segment.component_id == component_id
+                    && segment.kind == SegmentKind::Layer
+                    && segment.layer == Some(layer)
+            })
+            .map(|segment| segment.id)
+    }
+
+    pub(crate) fn map_segment_shared(
+        &self,
+        segment_id: u32,
+    ) -> Result<Arc<MappedSegment>, GgufrsError> {
+        let segment = self
+            .segment(segment_id)
+            .ok_or_else(|| invalid(format!("unknown segment id {segment_id}")))?;
+        let len = usize::try_from(segment.stored_len).map_err(|_| {
+            invalid(format!(
+                "component {} segment {} length does not fit usize",
+                segment.component_id, segment.id
+            ))
+        })?;
+        let bytes = unsafe {
+            MmapOptions::new()
+                .offset(segment.absolute_offset)
+                .len(len)
+                .map(&*self.file)
+        }
+        .map_err(|source| GgufrsError::Io {
+            operation: "map ggufrs segment",
+            path: (*self.path).clone(),
+            source,
+        })?;
+        let actual: [u8; 32] = Sha256::digest(&bytes).into();
+        if actual != segment.sha256 {
+            return Err(GgufrsError::ChecksumMismatch {
+                component_id: segment.component_id,
+                segment_id: segment.id,
+                expected: segment.sha256,
+                actual,
+            });
+        }
+        Ok(Arc::new(MappedSegment { segment_id, bytes }))
+    }
+}
+
+impl LoadedComponent {
+    pub fn component_id(&self) -> u32 {
+        self.component_id
+    }
+
+    pub fn map_segment(&mut self, segment_id: u32) -> Result<(), GgufrsError> {
+        let segment = self
+            .index
+            .segments
+            .get(segment_id as usize)
+            .filter(|segment| segment.id == segment_id)
+            .ok_or_else(|| invalid(format!("unknown segment id {segment_id}")))?;
+        if segment.component_id != self.component_id {
+            return Err(invalid(format!(
+                "component {} does not own segment {segment_id}",
+                self.component_id
+            )));
+        }
+        if self.mappings.contains_key(&segment_id) {
+            return Ok(());
+        }
+        let package = GgufrsFile {
+            file: Arc::clone(&self.file),
+            path: Arc::clone(&self.path),
+            index: Arc::clone(&self.index),
+        };
+        self.mappings
+            .insert(segment_id, package.map_segment_shared(segment_id)?);
+        Ok(())
+    }
+
+    pub fn unmap_segment(&mut self, segment_id: u32) -> Result<bool, GgufrsError> {
+        let segment = self
+            .index
+            .segments
+            .get(segment_id as usize)
+            .filter(|segment| segment.id == segment_id)
+            .ok_or_else(|| invalid(format!("unknown segment id {segment_id}")))?;
+        if segment.component_id != self.component_id {
+            return Err(invalid(format!(
+                "component {} does not own segment {segment_id}",
+                self.component_id
+            )));
+        }
+        Ok(self.mappings.remove(&segment_id).is_some())
+    }
+
+    pub fn is_segment_mapped(&self, segment_id: u32) -> bool {
+        self.mappings.contains_key(&segment_id)
+    }
+}
+
+impl TensorSource for LoadedComponent {
+    fn metadata(&self, key: &str) -> Option<&MetaValue> {
+        let index = *self
+            .index
+            .metadata_lookup
+            .get(&(self.component_id, key.to_string()))?;
+        Some(&self.index.metadata[index].value)
+    }
+
+    fn tensor_info(&self, name: &str) -> Option<&TensorInfo> {
+        self.tensor_infos.get(name)
+    }
+
+    fn tensor_slice(&self, name: &str) -> Option<&[u8]> {
+        let record_index = *self
+            .index
+            .tensor_lookup
+            .get(&(self.component_id, name.to_string()))?;
+        let record = &self.index.tensors[record_index];
+        let mapping = self.mappings.get(&record.segment_id)?;
+        debug_assert_eq!(mapping.segment_id, record.segment_id);
+        let start = usize::try_from(record.segment_offset).ok()?;
+        let len = usize::try_from(record.byte_len).ok()?;
+        mapping.bytes.get(start..start.checked_add(len)?)
+    }
+}
+
+pub fn open_model_source(
+    path: &Path,
+    role: ComponentRole,
+) -> Result<Box<dyn TensorSource>, GgufrsError> {
+    let mut file = File::open(path).map_err(|source| GgufrsError::Io {
+        operation: "open model source",
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let mut magic = [0u8; 8];
+    file.read_exact(&mut magic)
+        .map_err(|source| GgufrsError::Io {
+            operation: "read model magic",
+            path: path.to_path_buf(),
+            source,
+        })?;
+    // GGUFRS starts with GGUF, so the exact eight-byte magic must win.
+    if &magic == GGUFRS_MAGIC {
+        return GgufrsFile::open(path)?
+            .load_component(role)
+            .map(|component| Box::new(component) as Box<dyn TensorSource>);
+    }
+    if &magic[..4] == b"GGUF" {
+        return GGUFLoader::from_file(path)
+            .map(|loader| Box::new(loader) as Box<dyn TensorSource>)
+            .map_err(|message| GgufrsError::SourceGguf {
+                role,
+                path: path.to_path_buf(),
+                message,
+            });
+    }
+    Err(invalid(format!(
+        "unknown model magic in {}",
+        path.display()
+    )))
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::*;
+
+    fn test_put_u32(out: &mut Vec<u8>, value: u32) {
+        out.extend_from_slice(&value.to_le_bytes());
+    }
+
+    fn test_put_i32(out: &mut Vec<u8>, value: i32) {
+        out.extend_from_slice(&value.to_le_bytes());
+    }
+
+    fn test_put_u64(out: &mut Vec<u8>, value: u64) {
+        out.extend_from_slice(&value.to_le_bytes());
+    }
+
+    fn test_put_string(out: &mut Vec<u8>, value: &str) {
+        test_put_u64(out, value.len() as u64);
+        out.extend_from_slice(value.as_bytes());
+    }
+
+    fn test_put_component(
+        out: &mut Vec<u8>,
+        id: u32,
+        role: ComponentRole,
+        name: &str,
+        metadata_start: u32,
+        metadata_count: u32,
+        tensor_start: u32,
+        tensor_count: u32,
+        segment_start: u32,
+        segment_count: u32,
+    ) {
+        test_put_u32(out, id);
+        test_put_u32(out, role as u32);
+        test_put_string(out, name);
+        for value in [
+            metadata_start,
+            metadata_count,
+            tensor_start,
+            tensor_count,
+            segment_start,
+            segment_count,
+        ] {
+            test_put_u32(out, value);
+        }
+    }
+
+    fn test_put_tensor(
+        out: &mut Vec<u8>,
+        component_id: u32,
+        segment_id: u32,
+        name: &str,
+        ggml_type: GGMLType,
+        dims: &[u64],
+        segment_offset: u64,
+        byte_len: u64,
+    ) {
+        test_put_u32(out, component_id);
+        test_put_u32(out, segment_id);
+        test_put_string(out, name);
+        test_put_i32(out, ggml_type as i32);
+        test_put_u32(out, dims.len() as u32);
+        for dimension in dims {
+            test_put_u64(out, *dimension);
+        }
+        test_put_u64(out, segment_offset);
+        test_put_u64(out, byte_len);
+    }
+
+    fn test_put_segment(
+        out: &mut Vec<u8>,
+        id: u32,
+        component_id: u32,
+        kind: SegmentKind,
+        layer: Option<u32>,
+        absolute_offset: u64,
+        tensor_start: u32,
+        tensor_count: u32,
+        sha256: [u8; 32],
+    ) {
+        test_put_u32(out, id);
+        test_put_u32(out, component_id);
+        test_put_u32(out, kind as u32);
+        test_put_i32(out, layer.map(|value| value as i32).unwrap_or(-1));
+        test_put_u64(out, absolute_offset);
+        test_put_u64(out, GGUFRS_SEGMENT_ALIGNMENT);
+        test_put_u32(out, tensor_start);
+        test_put_u32(out, tensor_count);
+        out.extend_from_slice(&sha256);
+    }
+
+    fn package_fixture_bytes_with(
+        second_tensor_name: &str,
+        second_segment_id: u32,
+        second_segment_offset: u64,
+        segment0_tensor_count: u32,
+        segment1_tensor_start: u32,
+        segment1_tensor_count: u32,
+    ) -> Vec<u8> {
+        let mut components = Vec::new();
+        test_put_component(
+            &mut components,
+            0,
+            ComponentRole::Llm,
+            "llm",
+            0,
+            4,
+            0,
+            2,
+            0,
+            2,
+        );
+        test_put_component(
+            &mut components,
+            1,
+            ComponentRole::Mmproj,
+            "mmproj",
+            4,
+            1,
+            2,
+            1,
+            2,
+            1,
+        );
+
+        let mut metadata = Vec::new();
+        test_put_u32(&mut metadata, 0);
+        test_put_string(&mut metadata, "general.alignment");
+        test_put_i32(&mut metadata, MetaValueType::Uint32 as i32);
+        test_put_u32(&mut metadata, 32);
+        test_put_u32(&mut metadata, 0);
+        test_put_string(&mut metadata, "general.architecture");
+        test_put_i32(&mut metadata, MetaValueType::String as i32);
+        test_put_string(&mut metadata, "qwen3");
+        test_put_u32(&mut metadata, 0);
+        test_put_string(&mut metadata, "general.name");
+        test_put_i32(&mut metadata, MetaValueType::String as i32);
+        test_put_string(&mut metadata, "test-llm");
+        test_put_u32(&mut metadata, 0);
+        test_put_string(&mut metadata, "qwen3.block_count");
+        test_put_i32(&mut metadata, MetaValueType::Uint32 as i32);
+        test_put_u32(&mut metadata, 1);
+        test_put_u32(&mut metadata, 1);
+        test_put_string(&mut metadata, "general.name");
+        test_put_i32(&mut metadata, MetaValueType::String as i32);
+        test_put_string(&mut metadata, "test-mmproj");
+
+        let mut tensors = Vec::new();
+        test_put_tensor(
+            &mut tensors,
+            0,
+            0,
+            "token_embd.weight",
+            GGMLType::F32,
+            &[32],
+            0,
+            128,
+        );
+        test_put_tensor(
+            &mut tensors,
+            0,
+            second_segment_id,
+            second_tensor_name,
+            GGMLType::Q8_0,
+            &[32],
+            second_segment_offset,
+            34,
+        );
+        test_put_tensor(
+            &mut tensors,
+            1,
+            2,
+            "mm.0.weight",
+            GGMLType::F16,
+            &[32],
+            0,
+            64,
+        );
+
+        const SEGMENT_TABLE_LEN: u64 = 3 * 72;
+        let component_table = TableRange {
+            offset: SUPERBLOCK_LEN as u64,
+            length: components.len() as u64,
+        };
+        let metadata_table = TableRange {
+            offset: component_table.offset + component_table.length,
+            length: metadata.len() as u64,
+        };
+        let segment_table = TableRange {
+            offset: metadata_table.offset + metadata_table.length,
+            length: SEGMENT_TABLE_LEN,
+        };
+        let tensor_table = TableRange {
+            offset: segment_table.offset + segment_table.length,
+            length: tensors.len() as u64,
+        };
+        let table_end = tensor_table.offset + tensor_table.length;
+        let tensor_data_offset = (table_end + GGUFRS_SEGMENT_ALIGNMENT - 1)
+            / GGUFRS_SEGMENT_ALIGNMENT
+            * GGUFRS_SEGMENT_ALIGNMENT;
+
+        let mut payloads = vec![
+            vec![0u8; GGUFRS_SEGMENT_ALIGNMENT as usize],
+            vec![0u8; GGUFRS_SEGMENT_ALIGNMENT as usize],
+            vec![0u8; GGUFRS_SEGMENT_ALIGNMENT as usize],
+        ];
+        let second_payload = &mut payloads[second_segment_id as usize];
+        let second_start = second_segment_offset as usize;
+        second_payload[second_start..second_start + 2]
+            .copy_from_slice(&half::f16::from_f32(1.0).to_le_bytes());
+        second_payload[second_start + 2..second_start + 34].fill(1);
+        payloads[2][..64].fill(0x3c);
+
+        let hashes: Vec<[u8; 32]> = payloads
+            .iter()
+            .map(|payload| Sha256::digest(payload).into())
+            .collect();
+        let mut segments = Vec::new();
+        test_put_segment(
+            &mut segments,
+            0,
+            0,
+            SegmentKind::Shared,
+            None,
+            tensor_data_offset,
+            0,
+            segment0_tensor_count,
+            hashes[0],
+        );
+        test_put_segment(
+            &mut segments,
+            1,
+            0,
+            SegmentKind::Layer,
+            Some(0),
+            tensor_data_offset + GGUFRS_SEGMENT_ALIGNMENT,
+            segment1_tensor_start,
+            segment1_tensor_count,
+            hashes[1],
+        );
+        test_put_segment(
+            &mut segments,
+            2,
+            1,
+            SegmentKind::Component,
+            None,
+            tensor_data_offset + 2 * GGUFRS_SEGMENT_ALIGNMENT,
+            2,
+            1,
+            hashes[2],
+        );
+        assert_eq!(segments.len() as u64, SEGMENT_TABLE_LEN);
+
+        let declared_file_size = tensor_data_offset + 3 * GGUFRS_SEGMENT_ALIGNMENT;
+        let mut output = Vec::new();
+        output.extend_from_slice(GGUFRS_MAGIC);
+        test_put_u32(&mut output, GGUFRS_VERSION);
+        test_put_u32(&mut output, 0);
+        test_put_u64(&mut output, declared_file_size);
+        for count in [2, 5, 3, 3] {
+            test_put_u32(&mut output, count);
+        }
+        for table in [component_table, metadata_table, segment_table, tensor_table] {
+            test_put_u64(&mut output, table.offset);
+            test_put_u64(&mut output, table.length);
+        }
+        test_put_u64(&mut output, tensor_data_offset);
+        output.extend_from_slice(&[0u8; 16]);
+        assert_eq!(output.len(), SUPERBLOCK_LEN);
+        output.extend_from_slice(&components);
+        output.extend_from_slice(&metadata);
+        output.extend_from_slice(&segments);
+        output.extend_from_slice(&tensors);
+        output.resize(tensor_data_offset as usize, 0);
+        for payload in payloads {
+            output.extend_from_slice(&payload);
+        }
+        assert_eq!(output.len() as u64, declared_file_size);
+        output
+    }
+
+    pub(crate) fn package_fixture_bytes() -> Vec<u8> {
+        package_fixture_bytes_with("blk.0.weight", 1, 0, 1, 1, 1)
+    }
+
+    pub(crate) fn package_fixture_with_second_tensor(
+        name: &str,
+        segment_id: u32,
+        segment_offset: u64,
+        segment0_tensor_count: u32,
+        segment1_tensor_start: u32,
+        segment1_tensor_count: u32,
+    ) -> Vec<u8> {
+        package_fixture_bytes_with(
+            name,
+            segment_id,
+            segment_offset,
+            segment0_tensor_count,
+            segment1_tensor_start,
+            segment1_tensor_count,
+        )
+    }
+
+    static TEST_FILE_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+    pub(crate) fn write_package_bytes(bytes: &[u8]) -> PathBuf {
+        let id = TEST_FILE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let path =
+            std::env::temp_dir().join(format!("rmi-ggufrs-{}-{id}.ggufrs", std::process::id()));
+        std::fs::write(&path, bytes).unwrap();
+        path
+    }
+
+    pub(crate) fn test_package() -> (PathBuf, GgufrsFile) {
+        let path = write_package_bytes(&package_fixture_bytes());
+        let package = GgufrsFile::open(&path).unwrap();
+        (path, package)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn read_u64_at(bytes: &[u8], offset: usize) -> u64 {
+        u64::from_le_bytes(bytes[offset..offset + 8].try_into().unwrap())
+    }
+
+    fn put_u32_at(bytes: &mut [u8], offset: usize, value: u32) {
+        bytes[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
+    }
+
+    fn put_u64_at(bytes: &mut [u8], offset: usize, value: u64) {
+        bytes[offset..offset + 8].copy_from_slice(&value.to_le_bytes());
+    }
+
+    fn find_once(bytes: &[u8], needle: &[u8]) -> usize {
+        let mut matches = bytes
+            .windows(needle.len())
+            .enumerate()
+            .filter_map(|(offset, window)| (window == needle).then_some(offset));
+        let offset = matches.next().expect("fixture field exists");
+        assert!(matches.next().is_none(), "fixture field is unique");
+        offset
+    }
+
+    fn assert_invalid(bytes: Vec<u8>, expected: &str) {
+        use super::test_support::write_package_bytes;
+
+        let path = write_package_bytes(&bytes);
+        let error = match GgufrsFile::open(&path) {
+            Ok(_) => panic!("invalid fixture was accepted"),
+            Err(error) => error,
+        };
+        std::fs::remove_file(path).unwrap();
+        match error {
+            GgufrsError::InvalidFormat { context } => assert!(
+                context.contains(expected),
+                "expected {expected:?} in {context:?}"
+            ),
+            other => panic!("expected InvalidFormat, got {other}"),
+        }
+    }
+
+    fn assert_checksum_mismatch(bytes: Vec<u8>, segment_id: u32) {
+        use super::test_support::write_package_bytes;
+
+        let path = write_package_bytes(&bytes);
+        let package = GgufrsFile::open(&path).unwrap();
+        let error = match package.load_component(ComponentRole::Llm) {
+            Ok(_) => panic!("corrupt segment was accepted"),
+            Err(error) => error,
+        };
+        drop(package);
+        std::fs::remove_file(path).unwrap();
+        match error {
+            GgufrsError::ChecksumMismatch {
+                component_id: 0,
+                segment_id: actual_segment,
+                ..
+            } => assert_eq!(actual_segment, segment_id),
+            other => panic!("expected ChecksumMismatch, got {other}"),
+        }
+    }
+
+    #[test]
+    fn loaded_component_scopes_metadata_and_releases_segments() {
+        use super::test_support::test_package;
+
+        let (path, package) = test_package();
+        let mut llm = package.load_component(ComponentRole::Llm).unwrap();
+        let layer = package.layer_segment_id(llm.component_id(), 0).unwrap();
+
+        assert_eq!(
+            llm.metadata("general.name")
+                .and_then(MetaValue::to_string_val),
+            Some("test-llm")
+        );
+        assert!(llm.tensor_slice("blk.0.weight").is_some());
+        assert!(llm.unmap_segment(layer).unwrap());
+        assert!(llm.tensor_slice("blk.0.weight").is_none());
+        llm.map_segment(layer).unwrap();
+        assert!(llm.tensor_slice("blk.0.weight").is_some());
+
+        let mmproj = package.load_component(ComponentRole::Mmproj).unwrap();
+        assert_eq!(
+            mmproj
+                .metadata("general.name")
+                .and_then(MetaValue::to_string_val),
+            Some("test-mmproj")
+        );
+        drop(mmproj);
+        drop(llm);
+        drop(package);
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn rejects_unsupported_version() {
+        let mut bytes = test_support::package_fixture_bytes();
+        put_u32_at(&mut bytes, 8, GGUFRS_VERSION + 1);
+        assert_invalid(bytes, "version=2");
+    }
+
+    #[test]
+    fn rejects_nonzero_flags() {
+        let mut bytes = test_support::package_fixture_bytes();
+        put_u32_at(&mut bytes, 12, 1);
+        assert_invalid(bytes, "flags=1");
+    }
+
+    #[test]
+    fn rejects_declared_size_mismatch() {
+        let mut bytes = test_support::package_fixture_bytes();
+        let declared = read_u64_at(&bytes, 16);
+        put_u64_at(&mut bytes, 16, declared + 1);
+        assert_invalid(bytes, "does not match actual file size");
+    }
+
+    #[test]
+    fn rejects_nonzero_reserved_byte() {
+        let mut bytes = test_support::package_fixture_bytes();
+        bytes[SUPERBLOCK_LEN - 1] = 1;
+        assert_invalid(bytes, "reserved superblock bytes must be zero");
+    }
+
+    #[test]
+    fn rejects_table_outside_file() {
+        let mut bytes = test_support::package_fixture_bytes();
+        let outside = bytes.len() as u64 + 1;
+        put_u64_at(&mut bytes, 40, outside);
+        assert_invalid(bytes, "component table range");
+    }
+
+    #[test]
+    fn rejects_duplicate_component_metadata_key() {
+        let mut bytes = test_support::package_fixture_bytes();
+        let offset = find_once(&bytes, b"qwen3.block_count");
+        bytes[offset..offset + b"general.alignment".len()].copy_from_slice(b"general.alignment");
+        assert_invalid(bytes, "duplicate metadata key general.alignment");
+    }
+
+    #[test]
+    fn rejects_duplicate_component_tensor_name() {
+        let mut bytes =
+            test_support::package_fixture_with_second_tensor("other_embd.weight", 1, 0, 1, 1, 1);
+        let offset = find_once(&bytes, b"other_embd.weight");
+        bytes[offset..offset + b"token_embd.weight".len()].copy_from_slice(b"token_embd.weight");
+        assert_invalid(bytes, "duplicate tensor name token_embd.weight");
+    }
+
+    #[test]
+    fn rejects_bad_tensor_component_reference() {
+        let mut bytes = test_support::package_fixture_bytes();
+        let tensor_name = find_once(&bytes, b"token_embd.weight");
+        put_u32_at(&mut bytes, tensor_name - 16, 1);
+        assert_invalid(bytes, "tensor token_embd.weight belongs to component 1");
+    }
+
+    #[test]
+    fn rejects_bad_tensor_segment_reference() {
+        let mut bytes = test_support::package_fixture_bytes();
+        let tensor_name = find_once(&bytes, b"token_embd.weight");
+        put_u32_at(&mut bytes, tensor_name - 12, 1);
+        assert_invalid(bytes, "references component 0 segment 1");
+    }
+
+    #[test]
+    fn rejects_unaligned_segment() {
+        let mut bytes = test_support::package_fixture_bytes();
+        let segment_table = read_u64_at(&bytes, 72) as usize;
+        let offset = read_u64_at(&bytes, segment_table + 16);
+        put_u64_at(&mut bytes, segment_table + 16, offset + 1);
+        assert_invalid(bytes, "must be aligned");
+    }
+
+    #[test]
+    fn rejects_overlapping_segments() {
+        let mut bytes = test_support::package_fixture_bytes();
+        let segment_table = read_u64_at(&bytes, 72) as usize;
+        let first_offset = read_u64_at(&bytes, segment_table + 16);
+        put_u64_at(&mut bytes, segment_table + 72 + 16, first_offset);
+        assert_invalid(bytes, "overlaps the previous segment");
+    }
+
+    #[test]
+    fn rejects_tensor_length_mismatch() {
+        let mut bytes = test_support::package_fixture_bytes();
+        let tensor_name = find_once(&bytes, b"token_embd.weight");
+        let byte_len_offset = tensor_name + b"token_embd.weight".len() + 24;
+        put_u64_at(&mut bytes, byte_len_offset, 129);
+        assert_invalid(bytes, "byte length 129 differs from checked size 128");
+    }
+
+    #[test]
+    fn rejects_overlapping_tensors() {
+        let mut bytes =
+            test_support::package_fixture_with_second_tensor("zzzzz_embd.weight", 0, 128, 2, 2, 0);
+        let tensor_name = find_once(&bytes, b"zzzzz_embd.weight");
+        let segment_offset = tensor_name + b"zzzzz_embd.weight".len() + 16;
+        put_u64_at(&mut bytes, segment_offset, 96);
+        assert_invalid(
+            bytes,
+            "tensors token_embd.weight and zzzzz_embd.weight overlap",
+        );
+    }
+
+    #[test]
+    fn changed_tensor_byte_fails_checksum() {
+        let mut bytes = test_support::package_fixture_bytes();
+        let tensor_data_offset = read_u64_at(&bytes, 104) as usize;
+        bytes[tensor_data_offset] ^= 1;
+        assert_checksum_mismatch(bytes, 0);
+    }
+
+    #[test]
+    fn changed_trailing_padding_byte_fails_checksum() {
+        let mut bytes = test_support::package_fixture_bytes();
+        let tensor_data_offset = read_u64_at(&bytes, 104) as usize;
+        bytes[tensor_data_offset + 128] ^= 1;
+        assert_checksum_mismatch(bytes, 0);
+    }
+
+    #[test]
+    fn open_model_source_prefers_exact_ggufrs_magic() {
+        let path = test_support::write_package_bytes(&test_support::package_fixture_bytes());
+        let source = open_model_source(&path, ComponentRole::Llm).unwrap();
+        assert_eq!(
+            source
+                .metadata("general.name")
+                .and_then(MetaValue::to_string_val),
+            Some("test-llm")
+        );
+        drop(source);
+        std::fs::remove_file(path).unwrap();
+    }
+}

--- a/RustModelInference/src/ggufrs.rs
+++ b/RustModelInference/src/ggufrs.rs
@@ -6,7 +6,7 @@ use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fs::File;
-use std::io::{self, Read};
+use std::io::{self, Read, Seek, SeekFrom};
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -181,6 +181,13 @@ struct Superblock {
     tensor_data_offset: u64,
 }
 
+struct IndexTables {
+    components: Vec<u8>,
+    metadata: Vec<u8>,
+    segments: Vec<u8>,
+    tensors: Vec<u8>,
+}
+
 #[derive(Debug, Clone)]
 struct ScopedMetadata {
     component_id: u32,
@@ -342,8 +349,10 @@ fn read_superblock(bytes: &[u8]) -> Result<Superblock, GgufrsError> {
     })
 }
 
-fn validate_table_layout(superblock: &Superblock, bytes: &[u8]) -> Result<(), GgufrsError> {
-    let file_len = u64::try_from(bytes.len()).map_err(|_| invalid("file length exceeds u64"))?;
+fn validate_table_layout(
+    superblock: &Superblock,
+    file_len: u64,
+) -> Result<Range<u64>, GgufrsError> {
     if superblock.declared_file_size != file_len {
         return Err(invalid(format!(
             "declared file size {} does not match actual file size {file_len}",
@@ -383,33 +392,113 @@ fn validate_table_layout(superblock: &Superblock, bytes: &[u8]) -> Result<(), Gg
             superblock.tensor_data_offset
         )));
     }
-    let padding = checked_range(
+    checked_range(
         expected_offset,
         superblock.tensor_data_offset - expected_offset,
         file_len,
         "index padding",
     )?;
-    if bytes[padding].iter().any(|byte| *byte != 0) {
-        return Err(invalid("index padding before tensor data must be zero"));
+    Ok(expected_offset..superblock.tensor_data_offset)
+}
+
+fn read_file_range(
+    file: &mut File,
+    path: &Path,
+    table: TableRange,
+    context: &str,
+) -> Result<Vec<u8>, GgufrsError> {
+    let len = usize::try_from(table.length)
+        .map_err(|_| invalid(format!("{context} length does not fit usize")))?;
+    let mut bytes = Vec::new();
+    bytes
+        .try_reserve_exact(len)
+        .map_err(|_| invalid(format!("failed to allocate {context}")))?;
+    bytes.resize(len, 0);
+    file.seek(SeekFrom::Start(table.offset))
+        .and_then(|_| file.read_exact(&mut bytes))
+        .map_err(|source| GgufrsError::Io {
+            operation: "read ggufrs index table",
+            path: path.to_path_buf(),
+            source,
+        })?;
+    Ok(bytes)
+}
+
+fn verify_zero_file_range(
+    file: &mut File,
+    path: &Path,
+    range: Range<u64>,
+) -> Result<(), GgufrsError> {
+    file.seek(SeekFrom::Start(range.start))
+        .map_err(|source| GgufrsError::Io {
+            operation: "seek ggufrs index padding",
+            path: path.to_path_buf(),
+            source,
+        })?;
+    let mut remaining = range.end - range.start;
+    let mut buffer = [0u8; 8192];
+    while remaining != 0 {
+        let len = usize::try_from(remaining.min(buffer.len() as u64))
+            .expect("bounded padding read length fits usize");
+        file.read_exact(&mut buffer[..len])
+            .map_err(|source| GgufrsError::Io {
+                operation: "read ggufrs index padding",
+                path: path.to_path_buf(),
+                source,
+            })?;
+        if buffer[..len].iter().any(|byte| *byte != 0) {
+            return Err(invalid("index padding before tensor data must be zero"));
+        }
+        remaining -= len as u64;
     }
     Ok(())
 }
 
-fn table_bytes<'a>(
-    bytes: &'a [u8],
-    table: TableRange,
-    context: &str,
-) -> Result<&'a [u8], GgufrsError> {
-    let file_len = u64::try_from(bytes.len()).map_err(|_| invalid("file length exceeds u64"))?;
-    Ok(&bytes[checked_range(table.offset, table.length, file_len, context)?])
+fn read_index_tables(
+    file: &mut File,
+    path: &Path,
+    superblock: &Superblock,
+    file_len: u64,
+) -> Result<IndexTables, GgufrsError> {
+    let padding = validate_table_layout(superblock, file_len)?;
+    let tables = IndexTables {
+        components: read_file_range(file, path, superblock.component_table, "component table")?,
+        metadata: read_file_range(file, path, superblock.metadata_table, "metadata table")?,
+        segments: read_file_range(file, path, superblock.segment_table, "segment table")?,
+        tensors: read_file_range(file, path, superblock.tensor_table, "tensor table")?,
+    };
+    verify_zero_file_range(file, path, padding)?;
+    Ok(tables)
 }
 
-fn parse_index(superblock: &Superblock, bytes: &[u8]) -> Result<PackageIndex, GgufrsError> {
-    validate_table_layout(superblock, bytes)?;
+fn table_vec<T>(
+    count: u32,
+    table_len: usize,
+    minimum_entry_bytes: usize,
+    context: &str,
+) -> Result<Vec<T>, GgufrsError> {
+    let count = usize::try_from(count)
+        .map_err(|_| invalid(format!("{context} count does not fit usize")))?;
+    if count > table_len / minimum_entry_bytes {
+        return Err(invalid(format!("{context} count exceeds remaining bytes")));
+    }
+    let mut values = Vec::new();
+    values
+        .try_reserve_exact(count)
+        .map_err(|_| invalid(format!("failed to allocate {context} entries")))?;
+    Ok(values)
+}
 
-    let component_bytes = table_bytes(bytes, superblock.component_table, "component table")?;
+fn parse_index(superblock: &Superblock, tables: &IndexTables) -> Result<PackageIndex, GgufrsError> {
+    let component_bytes = tables.components.as_slice();
+
     let mut reader = ByteReader::new(component_bytes);
-    let mut components = Vec::new();
+    let mut components = table_vec(
+        superblock.component_count,
+        component_bytes.len(),
+        40,
+        "component table",
+    )?;
     for entry in 0..superblock.component_count {
         let context = format!("component {entry}");
         let id = reader
@@ -457,9 +546,14 @@ fn parse_index(superblock: &Superblock, bytes: &[u8]) -> Result<PackageIndex, Gg
         )));
     }
 
-    let metadata_bytes = table_bytes(bytes, superblock.metadata_table, "metadata table")?;
+    let metadata_bytes = tables.metadata.as_slice();
     let mut reader = ByteReader::new(metadata_bytes);
-    let mut metadata = Vec::new();
+    let mut metadata = table_vec(
+        superblock.metadata_count,
+        metadata_bytes.len(),
+        17,
+        "metadata table",
+    )?;
     for entry in 0..superblock.metadata_count {
         let context = format!("metadata {entry}");
         let component_id = reader
@@ -476,6 +570,17 @@ fn parse_index(superblock: &Superblock, bytes: &[u8]) -> Result<PackageIndex, Gg
                 "{context} key {key}: unknown metadata value type {value_type_raw}"
             ))
         })?;
+        if value_type == MetaValueType::Array {
+            let mut peek = ByteReader::new(&metadata_bytes[reader.pos()..]);
+            let element_type = peek
+                .read_i32()
+                .map_err(|message| invalid(format!("{context} key {key}: {message}")))?;
+            if element_type == MetaValueType::Array as i32 {
+                return Err(invalid(format!(
+                    "{context} key {key}: nested metadata arrays are not supported"
+                )));
+            }
+        }
         let value = reader
             .read_meta_value(value_type)
             .map_err(|message| invalid(format!("{context} key {key}: {message}")))?;
@@ -492,9 +597,14 @@ fn parse_index(superblock: &Superblock, bytes: &[u8]) -> Result<PackageIndex, Gg
         )));
     }
 
-    let segment_bytes = table_bytes(bytes, superblock.segment_table, "segment table")?;
+    let segment_bytes = tables.segments.as_slice();
     let mut reader = ByteReader::new(segment_bytes);
-    let mut segments = Vec::new();
+    let mut segments = table_vec(
+        superblock.segment_count,
+        segment_bytes.len(),
+        72,
+        "segment table",
+    )?;
     for entry in 0..superblock.segment_count {
         let context = format!("segment {entry}");
         let id = reader
@@ -556,9 +666,14 @@ fn parse_index(superblock: &Superblock, bytes: &[u8]) -> Result<PackageIndex, Gg
         )));
     }
 
-    let tensor_bytes = table_bytes(bytes, superblock.tensor_table, "tensor table")?;
+    let tensor_bytes = tables.tensors.as_slice();
     let mut reader = ByteReader::new(tensor_bytes);
-    let mut tensors = Vec::new();
+    let mut tensors = table_vec(
+        superblock.tensor_count,
+        tensor_bytes.len(),
+        40,
+        "tensor table",
+    )?;
     for entry in 0..superblock.tensor_count {
         let context = format!("tensor {entry}");
         let component_id = reader
@@ -579,7 +694,20 @@ fn parse_index(superblock: &Superblock, bytes: &[u8]) -> Result<PackageIndex, Gg
         let rank = reader
             .read_u32()
             .map_err(|message| invalid(format!("{tensor_context}: {message}")))?;
+        let rank = usize::try_from(rank)
+            .map_err(|_| invalid(format!("{tensor_context}: rank does not fit usize")))?;
+        let required = rank
+            .checked_mul(8)
+            .and_then(|bytes| bytes.checked_add(16))
+            .ok_or_else(|| invalid(format!("{tensor_context}: rank byte count overflow")))?;
+        if required > tensor_bytes.len().saturating_sub(reader.pos()) {
+            return Err(invalid(format!(
+                "{tensor_context}: rank exceeds remaining bytes including trailing offsets"
+            )));
+        }
         let mut dims = Vec::new();
+        dims.try_reserve_exact(rank)
+            .map_err(|_| invalid(format!("{tensor_context}: failed to allocate dimensions")))?;
         for _ in 0..rank {
             dims.push(
                 reader
@@ -622,7 +750,7 @@ fn parse_index(superblock: &Superblock, bytes: &[u8]) -> Result<PackageIndex, Gg
         metadata_lookup: BTreeMap::new(),
         tensor_lookup: BTreeMap::new(),
     };
-    validate_index(superblock, bytes, &mut index)?;
+    validate_index(superblock, &mut index)?;
     Ok(index)
 }
 
@@ -648,11 +776,7 @@ fn metadata_value<'a>(
         .map(|entry| &entry.value)
 }
 
-fn validate_index(
-    superblock: &Superblock,
-    _file_bytes: &[u8],
-    index: &mut PackageIndex,
-) -> Result<(), GgufrsError> {
+fn validate_index(superblock: &Superblock, index: &mut PackageIndex) -> Result<(), GgufrsError> {
     let mut roles = BTreeSet::new();
     let mut next_metadata = 0u32;
     let mut next_tensor = 0u32;
@@ -1079,7 +1203,7 @@ fn validate_index(
 impl GgufrsFile {
     pub fn open(path: impl AsRef<Path>) -> Result<Self, GgufrsError> {
         let path = path.as_ref().to_path_buf();
-        let file = File::open(&path).map_err(|source| GgufrsError::Io {
+        let mut file = File::open(&path).map_err(|source| GgufrsError::Io {
             operation: "open ggufrs",
             path: path.clone(),
             source,
@@ -1095,13 +1219,16 @@ impl GgufrsFile {
         if file_len < SUPERBLOCK_LEN as u64 {
             return Err(invalid("file is shorter than the 128-byte superblock"));
         }
-        let bytes = unsafe { MmapOptions::new().map(&file) }.map_err(|source| GgufrsError::Io {
-            operation: "map ggufrs index",
-            path: path.clone(),
-            source,
-        })?;
-        let superblock = read_superblock(&bytes)?;
-        let index = parse_index(&superblock, &bytes)?;
+        let mut header = [0u8; SUPERBLOCK_LEN];
+        file.read_exact(&mut header)
+            .map_err(|source| GgufrsError::Io {
+                operation: "read ggufrs superblock",
+                path: path.clone(),
+                source,
+            })?;
+        let superblock = read_superblock(&header)?;
+        let tables = read_index_tables(&mut file, &path, &superblock, file_len)?;
+        let index = parse_index(&superblock, &tables)?;
         Ok(Self {
             file: Arc::new(file),
             path: Arc::new(path),
@@ -1216,6 +1343,52 @@ impl GgufrsFile {
                 expected: segment.sha256,
                 actual,
             });
+        }
+        let mut used_ranges: Vec<Range<usize>> = segment
+            .tensor_range
+            .clone()
+            .map(|position| {
+                let tensor = &self.index.tensors[position as usize];
+                let start = usize::try_from(tensor.segment_offset).map_err(|_| {
+                    invalid(format!(
+                        "component {} segment {} tensor {} offset does not fit usize",
+                        segment.component_id, segment.id, tensor.info.name
+                    ))
+                })?;
+                let len = usize::try_from(tensor.byte_len).map_err(|_| {
+                    invalid(format!(
+                        "component {} segment {} tensor {} length does not fit usize",
+                        segment.component_id, segment.id, tensor.info.name
+                    ))
+                })?;
+                let end = start.checked_add(len).ok_or_else(|| {
+                    invalid(format!(
+                        "component {} segment {} tensor {} range overflow",
+                        segment.component_id, segment.id, tensor.info.name
+                    ))
+                })?;
+                Ok(start..end)
+            })
+            .collect::<Result<_, GgufrsError>>()?;
+        used_ranges.sort_unstable_by_key(|range| range.start);
+        let mut padding_start = 0usize;
+        for range in used_ranges {
+            if bytes[padding_start..range.start]
+                .iter()
+                .any(|byte| *byte != 0)
+            {
+                return Err(invalid(format!(
+                    "component {} segment {} has nonzero padding before byte {}",
+                    segment.component_id, segment.id, range.start
+                )));
+            }
+            padding_start = range.end;
+        }
+        if bytes[padding_start..].iter().any(|byte| *byte != 0) {
+            return Err(invalid(format!(
+                "component {} segment {} has nonzero padding after byte {padding_start}",
+                segment.component_id, segment.id
+            )));
         }
         Ok(Arc::new(MappedSegment { segment_id, bytes }))
     }
@@ -1723,6 +1896,18 @@ mod tests {
         }
     }
 
+    fn assert_count_exceeds_table(
+        mut bytes: Vec<u8>,
+        count_offset: usize,
+        table_length_offset: usize,
+        minimum_entry_bytes: u64,
+        table: &str,
+    ) {
+        let count = read_u64_at(&bytes, table_length_offset) / minimum_entry_bytes + 1;
+        put_u32_at(&mut bytes, count_offset, count as u32);
+        assert_invalid(bytes, &format!("{table} count exceeds remaining bytes"));
+    }
+
     #[test]
     fn loaded_component_scopes_metadata_and_releases_segments() {
         use super::test_support::test_package;
@@ -1790,6 +1975,73 @@ mod tests {
         let outside = bytes.len() as u64 + 1;
         put_u64_at(&mut bytes, 40, outside);
         assert_invalid(bytes, "component table range");
+    }
+
+    #[test]
+    fn rejects_component_count_exceeding_table() {
+        assert_count_exceeds_table(
+            test_support::package_fixture_bytes(),
+            24,
+            48,
+            40,
+            "component table",
+        );
+    }
+
+    #[test]
+    fn rejects_metadata_count_exceeding_table() {
+        assert_count_exceeds_table(
+            test_support::package_fixture_bytes(),
+            28,
+            64,
+            17,
+            "metadata table",
+        );
+    }
+
+    #[test]
+    fn rejects_segment_count_exceeding_table() {
+        assert_count_exceeds_table(
+            test_support::package_fixture_bytes(),
+            32,
+            80,
+            72,
+            "segment table",
+        );
+    }
+
+    #[test]
+    fn rejects_tensor_count_exceeding_table() {
+        assert_count_exceeds_table(
+            test_support::package_fixture_bytes(),
+            36,
+            96,
+            40,
+            "tensor table",
+        );
+    }
+
+    #[test]
+    fn rejects_tensor_rank_exceeding_remaining_entry_bytes() {
+        let mut bytes = test_support::package_fixture_bytes();
+        let tensor_name = find_once(&bytes, b"token_embd.weight");
+        let rank_offset = tensor_name + b"token_embd.weight".len() + 4;
+        put_u32_at(&mut bytes, rank_offset, u32::MAX);
+        assert_invalid(
+            bytes,
+            "rank exceeds remaining bytes including trailing offsets",
+        );
+    }
+
+    #[test]
+    fn rejects_nested_metadata_arrays_before_recursive_decode() {
+        let mut bytes = test_support::package_fixture_bytes();
+        let key = find_once(&bytes, b"general.architecture");
+        let value_type = key + b"general.architecture".len();
+        put_u32_at(&mut bytes, value_type, MetaValueType::Array as u32);
+        put_u32_at(&mut bytes, value_type + 4, MetaValueType::Array as u32);
+        put_u64_at(&mut bytes, value_type + 8, 1);
+        assert_invalid(bytes, "nested metadata arrays are not supported");
     }
 
     #[test]
@@ -1879,6 +2131,60 @@ mod tests {
         let tensor_data_offset = read_u64_at(&bytes, 104) as usize;
         bytes[tensor_data_offset + 128] ^= 1;
         assert_checksum_mismatch(bytes, 0);
+    }
+
+    #[test]
+    fn rejects_nonzero_segment_padding_with_matching_checksum() {
+        let mut bytes = test_support::package_fixture_bytes();
+        let segment_table = read_u64_at(&bytes, 72) as usize;
+        let tensor_data_offset = read_u64_at(&bytes, 104) as usize;
+        bytes[tensor_data_offset + 128] = 1;
+        let hash: [u8; 32] = Sha256::digest(
+            &bytes[tensor_data_offset..tensor_data_offset + GGUFRS_SEGMENT_ALIGNMENT as usize],
+        )
+        .into();
+        bytes[segment_table + 40..segment_table + 72].copy_from_slice(&hash);
+
+        let path = test_support::write_package_bytes(&bytes);
+        let package = GgufrsFile::open(&path).unwrap();
+        let result = package.load_component(ComponentRole::Llm);
+        drop(package);
+        std::fs::remove_file(path).unwrap();
+        match result {
+            Err(GgufrsError::InvalidFormat { context }) => assert!(
+                context.contains("nonzero padding"),
+                "expected nonzero padding context, got {context:?}"
+            ),
+            Err(other) => panic!("expected InvalidFormat, got {other}"),
+            Ok(_) => panic!("segment padding with a matching checksum was accepted"),
+        }
+    }
+
+    #[test]
+    fn open_does_not_map_sparse_segment_region() {
+        const SPARSE_FILE_LEN: u64 = 1 << 48;
+
+        let mut bytes = test_support::package_fixture_bytes();
+        let segment_table = read_u64_at(&bytes, 72) as usize;
+        let third_segment = segment_table + 2 * 72;
+        let third_offset = read_u64_at(&bytes, third_segment + 16);
+        put_u64_at(&mut bytes, 16, SPARSE_FILE_LEN);
+        put_u64_at(
+            &mut bytes,
+            third_segment + 24,
+            SPARSE_FILE_LEN - third_offset,
+        );
+
+        let path = test_support::write_package_bytes(&bytes);
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_len(SPARSE_FILE_LEN)
+            .unwrap();
+        let result = GgufrsFile::open(&path).map(|package| package.components().len());
+        std::fs::remove_file(path).unwrap();
+        assert_eq!(result.unwrap(), 2);
     }
 
     #[test]

--- a/RustModelInference/src/ggufrs.rs
+++ b/RustModelInference/src/ggufrs.rs
@@ -2039,6 +2039,15 @@ impl LoadedComponent {
         self.component_id
     }
 
+    pub fn component_metadata_entries(&self) -> impl Iterator<Item = (&String, &MetaValue)> + '_ {
+        let range = self.index.components[self.component_id as usize]
+            .metadata_range
+            .clone();
+        self.index.metadata[range.start as usize..range.end as usize]
+            .iter()
+            .map(|entry| (&entry.key, &entry.value))
+    }
+
     pub fn map_segment(&mut self, segment_id: u32) -> Result<(), GgufrsError> {
         let segment = self
             .index
@@ -3166,6 +3175,46 @@ mod tests {
                 .metadata("general.name")
                 .and_then(MetaValue::to_string_val),
             Some("test-mmproj")
+        );
+    }
+
+    #[test]
+    fn gguf_and_ggufrs_expose_the_same_tensor_contract() {
+        use super::test_support::*;
+
+        let fixture = test_gguf_pair();
+        let output = fixture.dir.join("model.ggufrs");
+        export_ggufrs(
+            &output,
+            &fixture.llm,
+            Some(&fixture.mmproj),
+            ExportOptions::default(),
+        )
+        .unwrap();
+
+        let gguf = GGUFLoader::from_file(&fixture.llm).unwrap();
+        let package = GgufrsFile::open(&output).unwrap();
+        let loaded = package.load_component(ComponentRole::Llm).unwrap();
+        for source_info in gguf.tensors() {
+            let loaded_info = loaded.tensor_info(&source_info.name).unwrap();
+            assert_eq!(loaded_info.name, source_info.name);
+            assert_eq!(loaded_info.dims, source_info.dims);
+            assert_eq!(loaded_info.ggml_type, source_info.ggml_type);
+            assert_eq!(
+                loaded.tensor_slice(&source_info.name).unwrap(),
+                gguf.tensor_slice(&source_info.name).unwrap()
+            );
+        }
+
+        let mut gguf_metadata = gguf
+            .metadata_entries()
+            .iter()
+            .map(|(key, value)| (key, value))
+            .collect::<Vec<_>>();
+        gguf_metadata.sort_by(|(left, _), (right, _)| left.as_bytes().cmp(right.as_bytes()));
+        assert_eq!(
+            gguf_metadata,
+            loaded.component_metadata_entries().collect::<Vec<_>>(),
         );
     }
 

--- a/RustModelInference/src/ggufrs.rs
+++ b/RustModelInference/src/ggufrs.rs
@@ -5,10 +5,11 @@ use memmap2::{Mmap, MmapOptions};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
-use std::fs::File;
-use std::io::{self, Read, Seek, SeekFrom};
+use std::fs::{File, OpenOptions};
+use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::ops::Range;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 pub const GGUFRS_VERSION: u32 = 1;
@@ -227,6 +228,29 @@ struct PackageIndex {
     tensor_lookup: BTreeMap<(u32, String), usize>,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ExportOptions {
+    pub overwrite: bool,
+}
+
+struct ExportSource {
+    role: ComponentRole,
+    path: PathBuf,
+    name: &'static str,
+    loader: GGUFLoader,
+    tensor_alignment: u64,
+}
+
+struct PlannedExport {
+    index: PackageIndex,
+    component_table: TableRange,
+    metadata_table: TableRange,
+    segment_table: TableRange,
+    tensor_table: TableRange,
+    tensor_data_offset: u64,
+    declared_file_size: u64,
+}
+
 #[derive(Clone)]
 pub struct GgufrsFile {
     file: Arc<File>,
@@ -252,6 +276,616 @@ fn invalid(context: impl Into<String>) -> GgufrsError {
     GgufrsError::InvalidFormat {
         context: context.into(),
     }
+}
+
+fn align_up(value: u64, alignment: u64) -> Option<u64> {
+    if alignment == 0 {
+        return None;
+    }
+    value
+        .checked_add(alignment.checked_sub(1)?)
+        .map(|value| value / alignment * alignment)
+}
+
+fn put_u32(out: &mut Vec<u8>, value: u32) {
+    out.extend_from_slice(&value.to_le_bytes());
+}
+
+fn put_i32(out: &mut Vec<u8>, value: i32) {
+    out.extend_from_slice(&value.to_le_bytes());
+}
+
+fn put_u64(out: &mut Vec<u8>, value: u64) {
+    out.extend_from_slice(&value.to_le_bytes());
+}
+
+fn put_string(out: &mut Vec<u8>, value: &str) -> Result<(), GgufrsError> {
+    put_u64(
+        out,
+        u64::try_from(value.len()).map_err(|_| invalid("string length does not fit u64"))?,
+    );
+    out.extend_from_slice(value.as_bytes());
+    Ok(())
+}
+
+fn meta_value_type(value: &MetaValue) -> MetaValueType {
+    match value {
+        MetaValue::Uint8(_) => MetaValueType::Uint8,
+        MetaValue::Int8(_) => MetaValueType::Int8,
+        MetaValue::Uint16(_) => MetaValueType::Uint16,
+        MetaValue::Int16(_) => MetaValueType::Int16,
+        MetaValue::Uint32(_) => MetaValueType::Uint32,
+        MetaValue::Int32(_) => MetaValueType::Int32,
+        MetaValue::Float32(_) => MetaValueType::Float32,
+        MetaValue::Bool(_) => MetaValueType::Bool,
+        MetaValue::String(_) => MetaValueType::String,
+        MetaValue::Uint64(_) => MetaValueType::Uint64,
+        MetaValue::Int64(_) => MetaValueType::Int64,
+        MetaValue::Float64(_) => MetaValueType::Float64,
+        MetaValue::Array(_, _) => MetaValueType::Array,
+    }
+}
+
+fn put_meta_value(out: &mut Vec<u8>, value: &MetaValue) -> Result<(), GgufrsError> {
+    match value {
+        MetaValue::Uint8(value) => out.push(*value),
+        MetaValue::Int8(value) => out.push(*value as u8),
+        MetaValue::Uint16(value) => out.extend_from_slice(&value.to_le_bytes()),
+        MetaValue::Int16(value) => out.extend_from_slice(&value.to_le_bytes()),
+        MetaValue::Uint32(value) => put_u32(out, *value),
+        MetaValue::Int32(value) => put_i32(out, *value),
+        MetaValue::Float32(value) => out.extend_from_slice(&value.to_le_bytes()),
+        MetaValue::Bool(value) => out.push(u8::from(*value)),
+        MetaValue::String(value) => put_string(out, value)?,
+        MetaValue::Uint64(value) => put_u64(out, *value),
+        MetaValue::Int64(value) => out.extend_from_slice(&value.to_le_bytes()),
+        MetaValue::Float64(value) => out.extend_from_slice(&value.to_le_bytes()),
+        MetaValue::Array(element_type, values) => {
+            if *element_type == MetaValueType::Array {
+                return Err(invalid("metadata arrays cannot contain arrays"));
+            }
+            for child in values {
+                if matches!(child, MetaValue::Array(_, _))
+                    || meta_value_type(child) != *element_type
+                {
+                    return Err(invalid(format!(
+                        "metadata array declares {element_type:?} but contains {:?}",
+                        meta_value_type(child)
+                    )));
+                }
+            }
+            put_i32(out, *element_type as i32);
+            put_u64(
+                out,
+                u64::try_from(values.len())
+                    .map_err(|_| invalid("metadata array length does not fit u64"))?,
+            );
+            for value in values {
+                put_meta_value(out, value)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn source_error(source: &ExportSource, message: impl Into<String>) -> GgufrsError {
+    GgufrsError::SourceGguf {
+        role: source.role,
+        path: source.path.clone(),
+        message: message.into(),
+    }
+}
+
+fn layer_index(name: &str) -> Option<u32> {
+    let rest = name.strip_prefix("blk.")?;
+    let (index, suffix) = rest.split_once('.')?;
+    if suffix.is_empty() {
+        return None;
+    }
+    index.parse().ok()
+}
+
+fn load_export_source(role: ComponentRole, path: &Path) -> Result<ExportSource, GgufrsError> {
+    let loader = GGUFLoader::from_file(path).map_err(|message| GgufrsError::SourceGguf {
+        role,
+        path: path.to_path_buf(),
+        message,
+    })?;
+    let source = ExportSource {
+        role,
+        path: path.to_path_buf(),
+        name: match role {
+            ComponentRole::Llm => "llm",
+            ComponentRole::Mmproj => "mmproj",
+        },
+        tensor_alignment: 32,
+        loader,
+    };
+    let alignment = source
+        .loader
+        .metadata("general.alignment")
+        .map(|value| {
+            value
+                .to_u64()
+                .ok_or_else(|| source_error(&source, "general.alignment is not an integer"))
+        })
+        .transpose()?
+        .unwrap_or(32);
+    if alignment == 0 || !alignment.is_power_of_two() {
+        return Err(source_error(
+            &source,
+            format!("general.alignment {alignment} is not a nonzero power of two"),
+        ));
+    }
+
+    match role {
+        ComponentRole::Llm => {
+            let architecture = source
+                .loader
+                .metadata("general.architecture")
+                .and_then(MetaValue::to_string_val)
+                .ok_or_else(|| source_error(&source, "missing or invalid general.architecture"))?;
+            if !matches!(architecture, "qwen2" | "qwen3" | "qwen35" | "llama") {
+                return Err(source_error(
+                    &source,
+                    format!("unsupported general.architecture {architecture}"),
+                ));
+            }
+            let block_key = format!("{architecture}.block_count");
+            let block_count = source
+                .loader
+                .metadata(&block_key)
+                .and_then(MetaValue::to_u64)
+                .and_then(|value| u32::try_from(value).ok())
+                .filter(|value| *value != 0 && *value <= i32::MAX as u32)
+                .ok_or_else(|| source_error(&source, format!("missing or invalid {block_key}")))?;
+            let required_tensors = u64::from(block_count).checked_add(1).ok_or_else(|| {
+                source_error(&source, format!("{block_key} tensor count overflow"))
+            })?;
+            let source_tensors = u64::try_from(source.loader.n_tensors())
+                .map_err(|_| source_error(&source, "source tensor count does not fit u64"))?;
+            if required_tensors > source_tensors {
+                return Err(source_error(
+                    &source,
+                    format!(
+                        "{block_key}={block_count} requires at least {required_tensors} tensors, source has {source_tensors}"
+                    ),
+                ));
+            }
+        }
+        ComponentRole::Mmproj => {
+            for key in [
+                "clip.vision.projection_dim",
+                "clip.vision.image_size",
+                "clip.vision.patch_size",
+                "clip.vision.embedding_length",
+                "clip.vision.feed_forward_length",
+                "clip.vision.block_count",
+                "clip.vision.attention.head_count",
+            ] {
+                if source
+                    .loader
+                    .metadata(key)
+                    .and_then(MetaValue::to_u64)
+                    .is_none()
+                {
+                    return Err(source_error(&source, format!("missing or invalid {key}")));
+                }
+            }
+            let epsilon = "clip.vision.attention.layer_norm_epsilon";
+            if source
+                .loader
+                .metadata(epsilon)
+                .and_then(MetaValue::to_f64)
+                .is_none()
+            {
+                return Err(source_error(
+                    &source,
+                    format!("missing or invalid {epsilon}"),
+                ));
+            }
+            for tensor in ["v.patch_embd.weight", "mm.0.weight", "mm.2.weight"] {
+                if source.loader.tensor_info(tensor).is_none() {
+                    return Err(source_error(
+                        &source,
+                        format!("missing required tensor {tensor}"),
+                    ));
+                }
+            }
+        }
+    }
+    Ok(ExportSource {
+        tensor_alignment: alignment.max(32),
+        ..source
+    })
+}
+
+fn vec_len_u32<T>(values: &[T], context: &str) -> Result<u32, GgufrsError> {
+    u32::try_from(values.len()).map_err(|_| invalid(format!("{context} count does not fit u32")))
+}
+
+fn plan_export(sources: &[ExportSource]) -> Result<PlannedExport, GgufrsError> {
+    if !matches!(
+        sources
+            .iter()
+            .map(|source| source.role)
+            .collect::<Vec<_>>()
+            .as_slice(),
+        [ComponentRole::Llm] | [ComponentRole::Llm, ComponentRole::Mmproj]
+    ) {
+        return Err(invalid("export sources must be [LLM] or [LLM, MMPROJ]"));
+    }
+
+    let mut index = PackageIndex {
+        components: Vec::new(),
+        metadata: Vec::new(),
+        segments: Vec::new(),
+        tensors: Vec::new(),
+        component_by_role: BTreeMap::new(),
+        metadata_lookup: BTreeMap::new(),
+        tensor_lookup: BTreeMap::new(),
+    };
+
+    for source in sources {
+        let component_id = vec_len_u32(&index.components, "component")?;
+        let metadata_start = vec_len_u32(&index.metadata, "metadata")?;
+        let mut metadata = source.loader.metadata_entries().to_vec();
+        metadata.sort_by(|left, right| left.0.as_bytes().cmp(right.0.as_bytes()));
+        for pair in metadata.windows(2) {
+            if pair[0].0 == pair[1].0 {
+                return Err(invalid(format!(
+                    "component {} has duplicate metadata key {}",
+                    source.name, pair[0].0
+                )));
+            }
+        }
+        index
+            .metadata
+            .extend(metadata.into_iter().map(|(key, value)| ScopedMetadata {
+                component_id,
+                key,
+                value,
+            }));
+        let metadata_end = vec_len_u32(&index.metadata, "metadata")?;
+
+        let segment_start = vec_len_u32(&index.segments, "segment")?;
+        let tensor_start = vec_len_u32(&index.tensors, "tensor")?;
+        let groups = match source.role {
+            ComponentRole::Llm => {
+                let architecture = source
+                    .loader
+                    .metadata("general.architecture")
+                    .and_then(MetaValue::to_string_val)
+                    .expect("validated LLM architecture");
+                let block_key = format!("{architecture}.block_count");
+                let block_count = source
+                    .loader
+                    .metadata(&block_key)
+                    .and_then(MetaValue::to_u64)
+                    .and_then(|value| u32::try_from(value).ok())
+                    .expect("validated LLM block count");
+                let group_count = usize::try_from(block_count)
+                    .map_err(|_| {
+                        invalid(format!(
+                            "component {} block count does not fit usize",
+                            source.name
+                        ))
+                    })?
+                    .checked_add(1)
+                    .ok_or_else(|| {
+                        invalid(format!("component {} segment count overflow", source.name))
+                    })?;
+                let mut groups: Vec<(SegmentKind, Option<u32>, Vec<TensorInfo>)> = Vec::new();
+                groups.try_reserve_exact(group_count).map_err(|_| {
+                    invalid(format!(
+                        "component {} failed to allocate {group_count} segment groups",
+                        source.name
+                    ))
+                })?;
+                groups.push((SegmentKind::Shared, None, Vec::new()));
+                groups.extend(
+                    (0..block_count).map(|layer| (SegmentKind::Layer, Some(layer), Vec::new())),
+                );
+                for tensor in source.loader.tensors() {
+                    let group = if let Some(layer) = layer_index(&tensor.name) {
+                        if layer >= block_count {
+                            return Err(invalid(format!(
+                                "component {} tensor {} layer {layer} is outside block count {block_count}",
+                                source.name, tensor.name
+                            )));
+                        }
+                        usize::try_from(layer)
+                            .ok()
+                            .and_then(|layer| layer.checked_add(1))
+                            .ok_or_else(|| {
+                                invalid(format!(
+                                    "component {} tensor {} layer index overflow",
+                                    source.name, tensor.name
+                                ))
+                            })?
+                    } else {
+                        0
+                    };
+                    groups[group].2.push(tensor.clone());
+                }
+                groups
+            }
+            ComponentRole::Mmproj => vec![(
+                SegmentKind::Component,
+                None,
+                source.loader.tensors().to_vec(),
+            )],
+        };
+
+        let mut component_tensor_names = BTreeSet::new();
+        for (kind, layer, mut tensors) in groups {
+            if tensors.is_empty() {
+                let label = match layer {
+                    Some(layer) => format!("layer {layer}"),
+                    None => format!("{kind:?}"),
+                };
+                return Err(invalid(format!(
+                    "component {} {label} segment has no tensors",
+                    source.name
+                )));
+            }
+            tensors.sort_by(|left, right| left.name.as_bytes().cmp(right.name.as_bytes()));
+            let segment_id = vec_len_u32(&index.segments, "segment")?;
+            let segment_tensor_start = vec_len_u32(&index.tensors, "tensor")?;
+            let mut cursor = 0u64;
+            for tensor in tensors {
+                if !component_tensor_names.insert(tensor.name.clone()) {
+                    return Err(invalid(format!(
+                        "component {} has duplicate tensor name {}",
+                        source.name, tensor.name
+                    )));
+                }
+                let segment_offset =
+                    align_up(cursor, source.tensor_alignment).ok_or_else(|| {
+                        invalid(format!(
+                            "component {} tensor {} aligned offset overflow",
+                            source.name, tensor.name
+                        ))
+                    })?;
+                let byte_len = tensor.checked_nbytes().ok_or_else(|| {
+                    invalid(format!(
+                        "component {} tensor {} dimensions/type do not form complete GGML blocks",
+                        source.name, tensor.name
+                    ))
+                })?;
+                let actual_len = source
+                    .loader
+                    .tensor_slice(&tensor.name)
+                    .and_then(|bytes| u64::try_from(bytes.len()).ok())
+                    .ok_or_else(|| {
+                        invalid(format!(
+                            "component {} tensor {} source bytes are unavailable",
+                            source.name, tensor.name
+                        ))
+                    })?;
+                if actual_len != byte_len {
+                    return Err(invalid(format!(
+                        "component {} tensor {} source length {actual_len} differs from checked size {byte_len}",
+                        source.name, tensor.name
+                    )));
+                }
+                cursor = segment_offset.checked_add(byte_len).ok_or_else(|| {
+                    invalid(format!(
+                        "component {} tensor {} end overflow",
+                        source.name, tensor.name
+                    ))
+                })?;
+                index.tensors.push(TensorRecord {
+                    component_id,
+                    segment_id,
+                    info: TensorInfo {
+                        name: tensor.name,
+                        dims: tensor.dims,
+                        ggml_type: tensor.ggml_type,
+                        offset: segment_offset,
+                    },
+                    segment_offset,
+                    byte_len,
+                });
+            }
+            let stored_len = align_up(cursor, GGUFRS_SEGMENT_ALIGNMENT).ok_or_else(|| {
+                invalid(format!(
+                    "component {} segment {segment_id} stored length overflow",
+                    source.name
+                ))
+            })?;
+            let segment_tensor_end = vec_len_u32(&index.tensors, "tensor")?;
+            index.segments.push(SegmentInfo {
+                id: segment_id,
+                component_id,
+                kind,
+                layer,
+                absolute_offset: 0,
+                stored_len,
+                tensor_range: segment_tensor_start..segment_tensor_end,
+                sha256: [0; 32],
+            });
+        }
+
+        let tensor_end = vec_len_u32(&index.tensors, "tensor")?;
+        let segment_end = vec_len_u32(&index.segments, "segment")?;
+        index.components.push(ComponentInfo {
+            id: component_id,
+            role: source.role,
+            name: source.name.into(),
+            metadata_range: metadata_start..metadata_end,
+            tensor_range: tensor_start..tensor_end,
+            segment_range: segment_start..segment_end,
+        });
+    }
+
+    let component_bytes = serialize_component_table(&index)?;
+    let metadata_bytes = serialize_metadata_table(&index)?;
+    let segment_bytes = serialize_segment_table(&index)?;
+    let tensor_bytes = serialize_tensor_table(&index)?;
+    let table_range = |offset: u64, bytes: &[u8], name: &str| -> Result<TableRange, GgufrsError> {
+        let length = u64::try_from(bytes.len())
+            .map_err(|_| invalid(format!("{name} length does not fit u64")))?;
+        offset
+            .checked_add(length)
+            .ok_or_else(|| invalid(format!("{name} range overflow")))?;
+        Ok(TableRange { offset, length })
+    };
+    let component_table = table_range(SUPERBLOCK_LEN as u64, &component_bytes, "component table")?;
+    let metadata_table = table_range(
+        component_table
+            .offset
+            .checked_add(component_table.length)
+            .ok_or_else(|| invalid("component table range overflow"))?,
+        &metadata_bytes,
+        "metadata table",
+    )?;
+    let segment_table = table_range(
+        metadata_table
+            .offset
+            .checked_add(metadata_table.length)
+            .ok_or_else(|| invalid("metadata table range overflow"))?,
+        &segment_bytes,
+        "segment table",
+    )?;
+    let tensor_table = table_range(
+        segment_table
+            .offset
+            .checked_add(segment_table.length)
+            .ok_or_else(|| invalid("segment table range overflow"))?,
+        &tensor_bytes,
+        "tensor table",
+    )?;
+    let table_end = tensor_table
+        .offset
+        .checked_add(tensor_table.length)
+        .ok_or_else(|| invalid("tensor table range overflow"))?;
+    let tensor_data_offset = align_up(table_end, GGUFRS_SEGMENT_ALIGNMENT)
+        .ok_or_else(|| invalid("tensor data offset overflow"))?;
+    let mut declared_file_size = tensor_data_offset;
+    for segment in &mut index.segments {
+        segment.absolute_offset = declared_file_size;
+        declared_file_size = declared_file_size
+            .checked_add(segment.stored_len)
+            .ok_or_else(|| invalid(format!("segment {} file range overflow", segment.id)))?;
+    }
+
+    Ok(PlannedExport {
+        index,
+        component_table,
+        metadata_table,
+        segment_table,
+        tensor_table,
+        tensor_data_offset,
+        declared_file_size,
+    })
+}
+
+fn serialize_component_table(index: &PackageIndex) -> Result<Vec<u8>, GgufrsError> {
+    let mut out = Vec::new();
+    for component in &index.components {
+        put_u32(&mut out, component.id);
+        put_u32(&mut out, component.role as u32);
+        put_string(&mut out, &component.name)?;
+        for range in [
+            &component.metadata_range,
+            &component.tensor_range,
+            &component.segment_range,
+        ] {
+            put_u32(&mut out, range.start);
+            put_u32(&mut out, range.end - range.start);
+        }
+    }
+    Ok(out)
+}
+
+fn serialize_metadata_table(index: &PackageIndex) -> Result<Vec<u8>, GgufrsError> {
+    let mut out = Vec::new();
+    for entry in &index.metadata {
+        put_u32(&mut out, entry.component_id);
+        put_string(&mut out, &entry.key)?;
+        put_i32(&mut out, meta_value_type(&entry.value) as i32);
+        put_meta_value(&mut out, &entry.value)?;
+    }
+    Ok(out)
+}
+
+fn serialize_segment_table(index: &PackageIndex) -> Result<Vec<u8>, GgufrsError> {
+    let mut out = Vec::new();
+    for segment in &index.segments {
+        put_u32(&mut out, segment.id);
+        put_u32(&mut out, segment.component_id);
+        put_u32(&mut out, segment.kind as u32);
+        let layer = segment
+            .layer
+            .map(|value| {
+                i32::try_from(value)
+                    .map_err(|_| invalid(format!("segment {} layer does not fit i32", segment.id)))
+            })
+            .transpose()?
+            .unwrap_or(-1);
+        put_i32(&mut out, layer);
+        put_u64(&mut out, segment.absolute_offset);
+        put_u64(&mut out, segment.stored_len);
+        put_u32(&mut out, segment.tensor_range.start);
+        put_u32(
+            &mut out,
+            segment.tensor_range.end - segment.tensor_range.start,
+        );
+        out.extend_from_slice(&segment.sha256);
+    }
+    Ok(out)
+}
+
+fn serialize_tensor_table(index: &PackageIndex) -> Result<Vec<u8>, GgufrsError> {
+    let mut out = Vec::new();
+    for tensor in &index.tensors {
+        put_u32(&mut out, tensor.component_id);
+        put_u32(&mut out, tensor.segment_id);
+        put_string(&mut out, &tensor.info.name)?;
+        put_i32(&mut out, tensor.info.ggml_type as i32);
+        put_u32(
+            &mut out,
+            u32::try_from(tensor.info.dims.len()).map_err(|_| {
+                invalid(format!("tensor {} rank does not fit u32", tensor.info.name))
+            })?,
+        );
+        for dimension in &tensor.info.dims {
+            put_u64(&mut out, *dimension);
+        }
+        put_u64(&mut out, tensor.segment_offset);
+        put_u64(&mut out, tensor.byte_len);
+    }
+    Ok(out)
+}
+
+fn serialize_superblock(plan: &PlannedExport) -> Result<[u8; 128], GgufrsError> {
+    let mut out = Vec::with_capacity(SUPERBLOCK_LEN);
+    out.extend_from_slice(GGUFRS_MAGIC);
+    put_u32(&mut out, GGUFRS_VERSION);
+    put_u32(&mut out, 0);
+    put_u64(&mut out, plan.declared_file_size);
+    for count in [
+        vec_len_u32(&plan.index.components, "component")?,
+        vec_len_u32(&plan.index.metadata, "metadata")?,
+        vec_len_u32(&plan.index.segments, "segment")?,
+        vec_len_u32(&plan.index.tensors, "tensor")?,
+    ] {
+        put_u32(&mut out, count);
+    }
+    for table in [
+        plan.component_table,
+        plan.metadata_table,
+        plan.segment_table,
+        plan.tensor_table,
+    ] {
+        put_u64(&mut out, table.offset);
+        put_u64(&mut out, table.length);
+    }
+    put_u64(&mut out, plan.tensor_data_offset);
+    out.extend_from_slice(&[0; 16]);
+    out.try_into()
+        .map_err(|_| invalid("superblock is not exactly 128 bytes"))
 }
 
 fn checked_range(
@@ -1473,6 +2107,383 @@ impl TensorSource for LoadedComponent {
     }
 }
 
+fn io_error(operation: &'static str, path: &Path, source: io::Error) -> GgufrsError {
+    GgufrsError::Io {
+        operation,
+        path: path.to_path_buf(),
+        source,
+    }
+}
+
+fn write_zeros(
+    file: &mut File,
+    path: &Path,
+    mut hasher: Option<&mut Sha256>,
+    mut len: u64,
+) -> Result<(), GgufrsError> {
+    const ZEROES: [u8; 8192] = [0; 8192];
+    while len != 0 {
+        let count_u64 = len.min(8192);
+        let count = usize::try_from(count_u64).map_err(|_| {
+            invalid(format!(
+                "padding chunk length {count_u64} does not fit usize"
+            ))
+        })?;
+        file.write_all(&ZEROES[..count])
+            .map_err(|source| GgufrsError::Io {
+                operation: "write package padding",
+                path: path.to_path_buf(),
+                source,
+            })?;
+        if let Some(hasher) = hasher.as_deref_mut() {
+            hasher.update(&ZEROES[..count]);
+        }
+        len = len
+            .checked_sub(count_u64)
+            .ok_or_else(|| invalid("package padding length underflow"))?;
+    }
+    Ok(())
+}
+
+fn write_planned_package(
+    file: &mut File,
+    path: &Path,
+    sources: &[ExportSource],
+    plan: &mut PlannedExport,
+) -> Result<(), GgufrsError> {
+    let superblock = serialize_superblock(plan)?;
+    let component_table = serialize_component_table(&plan.index)?;
+    let metadata_table = serialize_metadata_table(&plan.index)?;
+    let segment_table = serialize_segment_table(&plan.index)?;
+    let tensor_table = serialize_tensor_table(&plan.index)?;
+    for (name, bytes, range) in [
+        (
+            "component",
+            component_table.as_slice(),
+            plan.component_table,
+        ),
+        ("metadata", metadata_table.as_slice(), plan.metadata_table),
+        ("segment", segment_table.as_slice(), plan.segment_table),
+        ("tensor", tensor_table.as_slice(), plan.tensor_table),
+    ] {
+        let actual = u64::try_from(bytes.len())
+            .map_err(|_| invalid(format!("{name} table length does not fit u64")))?;
+        if actual != range.length {
+            return Err(invalid(format!(
+                "{name} table length {actual} differs from planned {}",
+                range.length
+            )));
+        }
+    }
+
+    file.seek(SeekFrom::Start(0))
+        .map_err(|source| io_error("seek to package start", path, source))?;
+    file.write_all(&superblock)
+        .map_err(|source| io_error("write package superblock", path, source))?;
+    for bytes in [
+        component_table.as_slice(),
+        metadata_table.as_slice(),
+        segment_table.as_slice(),
+        tensor_table.as_slice(),
+    ] {
+        file.write_all(bytes)
+            .map_err(|source| io_error("write package index table", path, source))?;
+    }
+    let table_end = file
+        .stream_position()
+        .map_err(|source| io_error("read package table end position", path, source))?;
+    let padding = plan
+        .tensor_data_offset
+        .checked_sub(table_end)
+        .ok_or_else(|| invalid("index tables extend past tensor data offset"))?;
+    write_zeros(file, path, None, padding)?;
+
+    for segment_index in 0..plan.index.segments.len() {
+        let (segment_id, component_id, stored_len, tensor_range) = {
+            let segment = &plan.index.segments[segment_index];
+            (
+                segment.id,
+                segment.component_id,
+                segment.stored_len,
+                segment.tensor_range.clone(),
+            )
+        };
+        let tensor_start = usize::try_from(tensor_range.start).map_err(|_| {
+            invalid(format!(
+                "segment {segment_id} tensor start does not fit usize"
+            ))
+        })?;
+        let tensor_end = usize::try_from(tensor_range.end).map_err(|_| {
+            invalid(format!(
+                "segment {segment_id} tensor end does not fit usize"
+            ))
+        })?;
+        let records = plan
+            .index
+            .tensors
+            .get(tensor_start..tensor_end)
+            .ok_or_else(|| {
+                invalid(format!(
+                    "segment {segment_id} tensor range {:?} is outside the tensor table",
+                    tensor_range
+                ))
+            })?;
+        let mut hasher = Sha256::new();
+        let mut cursor = 0u64;
+        for record in records {
+            if record.component_id != component_id {
+                return Err(invalid(format!(
+                    "segment {segment_id} contains tensor {} from component {}",
+                    record.info.name, record.component_id
+                )));
+            }
+            let gap = record.segment_offset.checked_sub(cursor).ok_or_else(|| {
+                invalid(format!(
+                    "component {component_id} segment {segment_id} tensor {} starts before cursor {cursor}",
+                    record.info.name
+                ))
+            })?;
+            write_zeros(file, path, Some(&mut hasher), gap)?;
+            let source_index = usize::try_from(record.component_id).map_err(|_| {
+                invalid(format!(
+                    "component {} does not fit the source index type",
+                    record.component_id
+                ))
+            })?;
+            let source = sources.get(source_index).ok_or_else(|| {
+                invalid(format!(
+                    "missing export source for component {}",
+                    record.component_id
+                ))
+            })?;
+            let bytes = source
+                .loader
+                .tensor_slice(&record.info.name)
+                .ok_or_else(|| {
+                    invalid(format!(
+                        "source tensor disappeared: component {} tensor {}",
+                        record.component_id, record.info.name
+                    ))
+                })?;
+            let actual_len = u64::try_from(bytes.len()).map_err(|_| {
+                invalid(format!(
+                    "source tensor length does not fit u64: {}",
+                    record.info.name
+                ))
+            })?;
+            if actual_len != record.byte_len {
+                return Err(invalid(format!(
+                    "source tensor length changed: component {} tensor {} expected {}, got {actual_len}",
+                    record.component_id, record.info.name, record.byte_len
+                )));
+            }
+            file.write_all(bytes)
+                .map_err(|source| io_error("write source tensor", path, source))?;
+            hasher.update(bytes);
+            cursor = record
+                .segment_offset
+                .checked_add(record.byte_len)
+                .ok_or_else(|| {
+                    invalid(format!(
+                        "component {} segment {segment_id} tensor {} end overflow",
+                        record.component_id, record.info.name
+                    ))
+                })?;
+        }
+        let trailing = stored_len.checked_sub(cursor).ok_or_else(|| {
+            invalid(format!(
+                "component {component_id} segment {segment_id} payload {cursor} exceeds stored length {stored_len}"
+            ))
+        })?;
+        write_zeros(file, path, Some(&mut hasher), trailing)?;
+        plan.index.segments[segment_index].sha256 = hasher.finalize().into();
+    }
+
+    let tensor_data_end = file
+        .stream_position()
+        .map_err(|source| io_error("read tensor-data end position", path, source))?;
+    if tensor_data_end != plan.declared_file_size {
+        return Err(invalid(format!(
+            "tensor data ended at {tensor_data_end}, expected {}",
+            plan.declared_file_size
+        )));
+    }
+
+    let segment_table = serialize_segment_table(&plan.index)?;
+    let segment_table_len = u64::try_from(segment_table.len())
+        .map_err(|_| invalid("segment table length does not fit u64"))?;
+    if segment_table_len != plan.segment_table.length {
+        return Err(invalid(format!(
+            "final segment table length {segment_table_len} differs from planned {}",
+            plan.segment_table.length
+        )));
+    }
+    file.seek(SeekFrom::Start(plan.segment_table.offset))
+        .map_err(|source| io_error("seek to segment table", path, source))?;
+    file.write_all(&segment_table)
+        .map_err(|source| io_error("rewrite segment table", path, source))?;
+    let superblock = serialize_superblock(plan)?;
+    file.seek(SeekFrom::Start(0))
+        .map_err(|source| io_error("seek to superblock", path, source))?;
+    file.write_all(&superblock)
+        .map_err(|source| io_error("rewrite superblock", path, source))?;
+    file.flush()
+        .map_err(|source| io_error("flush temporary package", path, source))?;
+    file.sync_all()
+        .map_err(|source| io_error("sync temporary package", path, source))?;
+    let actual_file_size = file
+        .seek(SeekFrom::End(0))
+        .map_err(|source| io_error("read final package size", path, source))?;
+    if actual_file_size != plan.declared_file_size {
+        return Err(invalid(format!(
+            "final package size {actual_file_size} differs from declared {}",
+            plan.declared_file_size
+        )));
+    }
+    Ok(())
+}
+
+static PENDING_OUTPUT_ID: AtomicU64 = AtomicU64::new(0);
+
+struct PendingOutput {
+    path: PathBuf,
+    output: PathBuf,
+    overwrite: bool,
+    published: bool,
+}
+
+impl PendingOutput {
+    fn create(output: &Path, overwrite: bool) -> Result<Self, GgufrsError> {
+        if output.file_name().filter(|name| !name.is_empty()).is_none() {
+            return Err(invalid(format!(
+                "output path has no file name: {}",
+                output.display()
+            )));
+        }
+        if !overwrite && output.exists() {
+            return Err(GgufrsError::OutputExists {
+                path: output.to_path_buf(),
+            });
+        }
+        let parent = output
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        loop {
+            let id = PENDING_OUTPUT_ID.fetch_add(1, Ordering::Relaxed);
+            let path = parent.join(format!(".ggufrs-{}-{id}.tmp", std::process::id()));
+            match OpenOptions::new().create_new(true).write(true).open(&path) {
+                Ok(file) => {
+                    drop(file);
+                    return Ok(Self {
+                        path,
+                        output: output.to_path_buf(),
+                        overwrite,
+                        published: false,
+                    });
+                }
+                Err(source) if source.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(source) => {
+                    return Err(GgufrsError::Io {
+                        operation: "create temporary package",
+                        path,
+                        source,
+                    });
+                }
+            }
+        }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn publish(mut self) -> Result<(), GgufrsError> {
+        GgufrsFile::open(&self.path)?.verify_all()?;
+        if self.overwrite {
+            std::fs::rename(&self.path, &self.output).map_err(|source| {
+                GgufrsError::UnsupportedPublish {
+                    path: self.output.clone(),
+                    operation: "atomic replacement rename",
+                    source,
+                }
+            })?;
+        } else {
+            match std::fs::hard_link(&self.path, &self.output) {
+                Ok(()) => std::fs::remove_file(&self.path).map_err(|source| GgufrsError::Io {
+                    operation: "remove published temporary link",
+                    path: self.path.clone(),
+                    source,
+                })?,
+                Err(source) if source.kind() == io::ErrorKind::AlreadyExists => {
+                    return Err(GgufrsError::OutputExists {
+                        path: self.output.clone(),
+                    });
+                }
+                Err(source) => {
+                    return Err(GgufrsError::UnsupportedPublish {
+                        path: self.output.clone(),
+                        operation: "no-replace hard link",
+                        source,
+                    });
+                }
+            }
+        }
+        self.published = true;
+        let parent = self
+            .output
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        File::open(parent)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|source| GgufrsError::Io {
+                operation: "sync output directory",
+                path: parent.to_path_buf(),
+                source,
+            })
+    }
+}
+
+impl Drop for PendingOutput {
+    fn drop(&mut self) {
+        if !self.published {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+pub fn export_ggufrs(
+    output: &Path,
+    llm: &Path,
+    mmproj: Option<&Path>,
+    options: ExportOptions,
+) -> Result<(), GgufrsError> {
+    if !options.overwrite && output.exists() {
+        return Err(GgufrsError::OutputExists {
+            path: output.to_path_buf(),
+        });
+    }
+    let mut sources = vec![load_export_source(ComponentRole::Llm, llm)?];
+    if let Some(path) = mmproj {
+        sources.push(load_export_source(ComponentRole::Mmproj, path)?);
+    }
+    let mut plan = plan_export(&sources)?;
+    let pending = PendingOutput::create(output, options.overwrite)?;
+    let mut file = OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(pending.path())
+        .map_err(|source| GgufrsError::Io {
+            operation: "open temporary package",
+            path: pending.path().to_path_buf(),
+            source,
+        })?;
+    write_planned_package(&mut file, pending.path(), &sources, &mut plan)?;
+    drop(file);
+    pending.publish()
+}
+
 pub fn open_model_source(
     path: &Path,
     role: ComponentRole,
@@ -1829,11 +2840,549 @@ pub(crate) mod test_support {
         let package = GgufrsFile::open(&path).unwrap();
         (path, package)
     }
+
+    #[derive(Clone)]
+    pub(crate) struct SourceTensor {
+        pub(crate) name: &'static str,
+        pub(crate) ggml_type: GGMLType,
+        pub(crate) dims: Vec<u64>,
+        pub(crate) bytes: Vec<u8>,
+    }
+
+    fn test_meta_type(value: &MetaValue) -> MetaValueType {
+        match value {
+            MetaValue::Uint8(_) => MetaValueType::Uint8,
+            MetaValue::Int8(_) => MetaValueType::Int8,
+            MetaValue::Uint16(_) => MetaValueType::Uint16,
+            MetaValue::Int16(_) => MetaValueType::Int16,
+            MetaValue::Uint32(_) => MetaValueType::Uint32,
+            MetaValue::Int32(_) => MetaValueType::Int32,
+            MetaValue::Float32(_) => MetaValueType::Float32,
+            MetaValue::Bool(_) => MetaValueType::Bool,
+            MetaValue::String(_) => MetaValueType::String,
+            MetaValue::Uint64(_) => MetaValueType::Uint64,
+            MetaValue::Int64(_) => MetaValueType::Int64,
+            MetaValue::Float64(_) => MetaValueType::Float64,
+            MetaValue::Array(_, _) => MetaValueType::Array,
+        }
+    }
+
+    fn test_put_meta_value(out: &mut Vec<u8>, value: &MetaValue) {
+        match value {
+            MetaValue::Uint8(value) => out.push(*value),
+            MetaValue::Int8(value) => out.push(*value as u8),
+            MetaValue::Uint16(value) => out.extend_from_slice(&value.to_le_bytes()),
+            MetaValue::Int16(value) => out.extend_from_slice(&value.to_le_bytes()),
+            MetaValue::Uint32(value) => test_put_u32(out, *value),
+            MetaValue::Int32(value) => test_put_i32(out, *value),
+            MetaValue::Float32(value) => out.extend_from_slice(&value.to_le_bytes()),
+            MetaValue::Bool(value) => out.push(u8::from(*value)),
+            MetaValue::String(value) => test_put_string(out, value),
+            MetaValue::Uint64(value) => test_put_u64(out, *value),
+            MetaValue::Int64(value) => out.extend_from_slice(&value.to_le_bytes()),
+            MetaValue::Float64(value) => out.extend_from_slice(&value.to_le_bytes()),
+            MetaValue::Array(element_type, values) => {
+                test_put_i32(out, *element_type as i32);
+                test_put_u64(out, values.len() as u64);
+                for value in values {
+                    test_put_meta_value(out, value);
+                }
+            }
+        }
+    }
+
+    pub(crate) fn write_test_gguf(
+        path: &Path,
+        metadata: &[(String, MetaValue)],
+        tensors: &[SourceTensor],
+    ) {
+        let mut output = Vec::new();
+        output.extend_from_slice(b"GGUF");
+        test_put_u32(&mut output, 3);
+        test_put_u64(&mut output, tensors.len() as u64);
+        test_put_u64(&mut output, metadata.len() as u64);
+        for (key, value) in metadata {
+            test_put_string(&mut output, key);
+            test_put_i32(&mut output, test_meta_type(value) as i32);
+            test_put_meta_value(&mut output, value);
+        }
+
+        let mut relative_offset = 0u64;
+        for tensor in tensors {
+            assert_eq!(
+                tensor.bytes.len() as u64,
+                TensorInfo {
+                    name: tensor.name.into(),
+                    dims: tensor.dims.clone(),
+                    ggml_type: tensor.ggml_type,
+                    offset: relative_offset,
+                }
+                .checked_nbytes()
+                .unwrap()
+            );
+            test_put_string(&mut output, tensor.name);
+            test_put_u32(&mut output, tensor.dims.len() as u32);
+            for dimension in &tensor.dims {
+                test_put_u64(&mut output, *dimension);
+            }
+            test_put_i32(&mut output, tensor.ggml_type as i32);
+            test_put_u64(&mut output, relative_offset);
+            relative_offset = align_up(relative_offset + tensor.bytes.len() as u64, 32).unwrap();
+        }
+
+        output.resize(align_up(output.len() as u64, 32).unwrap() as usize, 0);
+        for tensor in tensors {
+            output.extend_from_slice(&tensor.bytes);
+            output.resize(align_up(output.len() as u64, 32).unwrap() as usize, 0);
+        }
+        std::fs::write(path, output).unwrap();
+    }
+
+    pub(crate) struct TestInputs {
+        pub(crate) dir: PathBuf,
+        pub(crate) llm: PathBuf,
+        pub(crate) mmproj: PathBuf,
+        pub(crate) llm_shared: Vec<u8>,
+        pub(crate) llm_blk0: Vec<u8>,
+        pub(crate) llm_blk1: Vec<u8>,
+        pub(crate) mmproj_weight: Vec<u8>,
+    }
+
+    impl Drop for TestInputs {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+
+    pub(crate) fn test_gguf_pair() -> TestInputs {
+        let id = TEST_FILE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let dir =
+            std::env::temp_dir().join(format!("rmi-ggufrs-export-{}-{id}", std::process::id()));
+        std::fs::create_dir(&dir).unwrap();
+        let llm = dir.join("llm.gguf");
+        let mmproj = dir.join("mmproj.gguf");
+        let llm_shared = vec![0x11; 128];
+        let mut llm_blk0 = vec![0x22; 34];
+        llm_blk0[..2].copy_from_slice(&half::f16::from_f32(1.0).to_bits().to_le_bytes());
+        let mut llm_blk1 = vec![0x33; 34];
+        llm_blk1[..2].copy_from_slice(&half::f16::from_f32(0.5).to_bits().to_le_bytes());
+        let mmproj_weight = vec![0x44; 64];
+
+        write_test_gguf(
+            &llm,
+            &[
+                ("general.alignment".into(), MetaValue::Uint32(32)),
+                (
+                    "general.architecture".into(),
+                    MetaValue::String("qwen3".into()),
+                ),
+                ("general.name".into(), MetaValue::String("test-llm".into())),
+                ("qwen3.block_count".into(), MetaValue::Uint32(2)),
+            ],
+            &[
+                SourceTensor {
+                    name: "token_embd.weight",
+                    ggml_type: GGMLType::F32,
+                    dims: vec![32],
+                    bytes: llm_shared.clone(),
+                },
+                SourceTensor {
+                    name: "blk.0.weight",
+                    ggml_type: GGMLType::Q8_0,
+                    dims: vec![32],
+                    bytes: llm_blk0.clone(),
+                },
+                SourceTensor {
+                    name: "blk.1.weight",
+                    ggml_type: GGMLType::Q8_0,
+                    dims: vec![32],
+                    bytes: llm_blk1.clone(),
+                },
+            ],
+        );
+        write_test_gguf(
+            &mmproj,
+            &[
+                (
+                    "clip.vision.attention.head_count".into(),
+                    MetaValue::Uint32(1),
+                ),
+                (
+                    "clip.vision.attention.layer_norm_epsilon".into(),
+                    MetaValue::Float32(1e-6),
+                ),
+                ("clip.vision.block_count".into(), MetaValue::Uint32(1)),
+                ("clip.vision.embedding_length".into(), MetaValue::Uint32(32)),
+                (
+                    "clip.vision.feed_forward_length".into(),
+                    MetaValue::Uint32(32),
+                ),
+                ("clip.vision.image_size".into(), MetaValue::Uint32(32)),
+                ("clip.vision.patch_size".into(), MetaValue::Uint32(16)),
+                ("clip.vision.projection_dim".into(), MetaValue::Uint32(32)),
+                ("general.alignment".into(), MetaValue::Uint32(32)),
+                (
+                    "general.name".into(),
+                    MetaValue::String("test-mmproj".into()),
+                ),
+            ],
+            &[
+                SourceTensor {
+                    name: "v.patch_embd.weight",
+                    ggml_type: GGMLType::F16,
+                    dims: vec![32],
+                    bytes: vec![0x55; 64],
+                },
+                SourceTensor {
+                    name: "mm.0.weight",
+                    ggml_type: GGMLType::F16,
+                    dims: vec![32],
+                    bytes: mmproj_weight.clone(),
+                },
+                SourceTensor {
+                    name: "mm.2.weight",
+                    ggml_type: GGMLType::F16,
+                    dims: vec![32],
+                    bytes: vec![0x66; 64],
+                },
+            ],
+        );
+        TestInputs {
+            dir,
+            llm,
+            mmproj,
+            llm_shared,
+            llm_blk0,
+            llm_blk1,
+            mmproj_weight,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn export_is_deterministic_scoped_and_byte_exact() {
+        use super::test_support::*;
+
+        let inputs = test_gguf_pair();
+        let a = inputs.dir.join("a.ggufrs");
+        let b = inputs.dir.join("b.ggufrs");
+        export_ggufrs(
+            &a,
+            &inputs.llm,
+            Some(&inputs.mmproj),
+            ExportOptions::default(),
+        )
+        .unwrap();
+        export_ggufrs(
+            &b,
+            &inputs.llm,
+            Some(&inputs.mmproj),
+            ExportOptions::default(),
+        )
+        .unwrap();
+        assert_eq!(std::fs::read(&a).unwrap(), std::fs::read(&b).unwrap());
+
+        let package = GgufrsFile::open(&a).unwrap();
+        package.verify_all().unwrap();
+        let llm = package.load_component(ComponentRole::Llm).unwrap();
+        let mmproj = package.load_component(ComponentRole::Mmproj).unwrap();
+        assert_eq!(
+            llm.tensor_slice("token_embd.weight").unwrap(),
+            inputs.llm_shared
+        );
+        assert_eq!(llm.tensor_slice("blk.0.weight").unwrap(), inputs.llm_blk0);
+        assert_eq!(llm.tensor_slice("blk.1.weight").unwrap(), inputs.llm_blk1);
+        assert_eq!(
+            mmproj.tensor_slice("mm.0.weight").unwrap(),
+            inputs.mmproj_weight
+        );
+        assert_eq!(
+            llm.metadata("general.name")
+                .and_then(MetaValue::to_string_val),
+            Some("test-llm")
+        );
+        assert_eq!(
+            mmproj
+                .metadata("general.name")
+                .and_then(MetaValue::to_string_val),
+            Some("test-mmproj")
+        );
+    }
+
+    #[test]
+    fn export_supports_llm_without_mmproj() {
+        let inputs = test_support::test_gguf_pair();
+        let output = inputs.dir.join("llm-only.ggufrs");
+
+        export_ggufrs(&output, &inputs.llm, None, ExportOptions::default()).unwrap();
+
+        let package = GgufrsFile::open(output).unwrap();
+        package.verify_all().unwrap();
+        assert_eq!(package.components().len(), 1);
+        assert!(package.component_id(ComponentRole::Llm).is_some());
+        assert!(package.component_id(ComponentRole::Mmproj).is_none());
+    }
+
+    #[test]
+    fn export_never_clobbers_without_explicit_overwrite() {
+        use super::test_support::*;
+
+        let inputs = test_gguf_pair();
+        let output = inputs.dir.join("model.ggufrs");
+        std::fs::write(&output, b"keep-me").unwrap();
+        let error = export_ggufrs(
+            &output,
+            &inputs.llm,
+            Some(&inputs.mmproj),
+            ExportOptions::default(),
+        )
+        .unwrap_err();
+        assert!(matches!(error, GgufrsError::OutputExists { .. }));
+        assert_eq!(std::fs::read(&output).unwrap(), b"keep-me");
+
+        export_ggufrs(
+            &output,
+            &inputs.llm,
+            Some(&inputs.mmproj),
+            ExportOptions { overwrite: true },
+        )
+        .unwrap();
+        GgufrsFile::open(output).unwrap().verify_all().unwrap();
+    }
+
+    #[test]
+    fn failed_validation_removes_only_the_new_temp_file() {
+        use super::test_support::*;
+
+        let inputs = test_gguf_pair();
+        let output = inputs.dir.join("model.ggufrs");
+        let temp = PendingOutput::create(&output, false).unwrap();
+        std::fs::write(temp.path(), b"not-a-package").unwrap();
+        let path = temp.path().to_path_buf();
+        assert!(temp.publish().is_err());
+        assert!(!path.exists());
+        assert!(!output.exists());
+        assert!(inputs.llm.exists());
+        assert!(inputs.mmproj.exists());
+    }
+
+    #[test]
+    fn no_clobber_publish_loses_race_without_replacing_winner() {
+        let inputs = test_support::test_gguf_pair();
+        let output = inputs.dir.join("model.ggufrs");
+        let temp = PendingOutput::create(&output, false).unwrap();
+        std::fs::write(temp.path(), test_support::package_fixture_bytes()).unwrap();
+        let temp_path = temp.path().to_path_buf();
+        std::fs::write(&output, b"race-winner").unwrap();
+
+        let error = temp.publish().unwrap_err();
+
+        assert!(matches!(error, GgufrsError::OutputExists { .. }));
+        assert_eq!(std::fs::read(&output).unwrap(), b"race-winner");
+        assert!(!temp_path.exists());
+    }
+
+    fn rewrite_test_llm(inputs: &test_support::TestInputs, metadata: &[(String, MetaValue)]) {
+        use super::test_support::{write_test_gguf, SourceTensor};
+
+        write_test_gguf(
+            &inputs.llm,
+            metadata,
+            &[
+                SourceTensor {
+                    name: "token_embd.weight",
+                    ggml_type: GGMLType::F32,
+                    dims: vec![32],
+                    bytes: inputs.llm_shared.clone(),
+                },
+                SourceTensor {
+                    name: "blk.0.weight",
+                    ggml_type: GGMLType::Q8_0,
+                    dims: vec![32],
+                    bytes: inputs.llm_blk0.clone(),
+                },
+                SourceTensor {
+                    name: "blk.1.weight",
+                    ggml_type: GGMLType::Q8_0,
+                    dims: vec![32],
+                    bytes: inputs.llm_blk1.clone(),
+                },
+            ],
+        );
+    }
+
+    #[test]
+    fn export_rejects_invalid_source_alignment() {
+        let inputs = test_support::test_gguf_pair();
+        rewrite_test_llm(
+            &inputs,
+            &[
+                ("general.alignment".into(), MetaValue::Uint32(3)),
+                (
+                    "general.architecture".into(),
+                    MetaValue::String("qwen3".into()),
+                ),
+                ("qwen3.block_count".into(), MetaValue::Uint32(2)),
+            ],
+        );
+
+        let error = export_ggufrs(
+            &inputs.dir.join("model.ggufrs"),
+            &inputs.llm,
+            None,
+            ExportOptions::default(),
+        )
+        .unwrap_err();
+
+        match error {
+            GgufrsError::SourceGguf { message, .. } => {
+                assert!(message.contains("nonzero power of two"), "{message}")
+            }
+            other => panic!("expected SourceGguf, got {other}"),
+        }
+    }
+
+    #[test]
+    fn export_rejects_block_count_larger_than_source_tensor_budget() {
+        let inputs = test_support::test_gguf_pair();
+        rewrite_test_llm(
+            &inputs,
+            &[
+                (
+                    "general.architecture".into(),
+                    MetaValue::String("qwen3".into()),
+                ),
+                ("qwen3.block_count".into(), MetaValue::Uint32(10)),
+            ],
+        );
+
+        let error = export_ggufrs(
+            &inputs.dir.join("model.ggufrs"),
+            &inputs.llm,
+            None,
+            ExportOptions::default(),
+        )
+        .unwrap_err();
+
+        match error {
+            GgufrsError::SourceGguf { message, .. } => {
+                assert!(
+                    message.contains("requires at least 11 tensors"),
+                    "{message}"
+                )
+            }
+            other => panic!("expected SourceGguf, got {other}"),
+        }
+    }
+
+    #[test]
+    fn export_rejects_nested_metadata_arrays() {
+        let inputs = test_support::test_gguf_pair();
+        rewrite_test_llm(
+            &inputs,
+            &[
+                (
+                    "general.architecture".into(),
+                    MetaValue::String("qwen3".into()),
+                ),
+                ("qwen3.block_count".into(), MetaValue::Uint32(2)),
+                (
+                    "test.nested".into(),
+                    MetaValue::Array(
+                        MetaValueType::Array,
+                        vec![MetaValue::Array(
+                            MetaValueType::Uint32,
+                            vec![MetaValue::Uint32(1)],
+                        )],
+                    ),
+                ),
+            ],
+        );
+
+        let error = export_ggufrs(
+            &inputs.dir.join("model.ggufrs"),
+            &inputs.llm,
+            None,
+            ExportOptions::default(),
+        )
+        .unwrap_err();
+
+        match error {
+            GgufrsError::InvalidFormat { context } => {
+                assert!(context.contains("metadata array"), "{context}")
+            }
+            other => panic!("expected InvalidFormat, got {other}"),
+        }
+    }
+
+    #[test]
+    fn metadata_writer_rejects_empty_nested_array_before_writing() {
+        let mut out = vec![0xaa];
+
+        let error = put_meta_value(
+            &mut out,
+            &MetaValue::Array(MetaValueType::Array, Vec::new()),
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, GgufrsError::InvalidFormat { .. }));
+        assert_eq!(out, [0xaa]);
+    }
+
+    #[test]
+    fn export_rejects_out_of_range_llm_layer() {
+        let inputs = test_support::test_gguf_pair();
+        use super::test_support::{write_test_gguf, SourceTensor};
+        write_test_gguf(
+            &inputs.llm,
+            &[
+                (
+                    "general.architecture".into(),
+                    MetaValue::String("qwen3".into()),
+                ),
+                ("qwen3.block_count".into(), MetaValue::Uint32(2)),
+            ],
+            &[
+                SourceTensor {
+                    name: "token_embd.weight",
+                    ggml_type: GGMLType::F32,
+                    dims: vec![32],
+                    bytes: inputs.llm_shared.clone(),
+                },
+                SourceTensor {
+                    name: "blk.0.weight",
+                    ggml_type: GGMLType::Q8_0,
+                    dims: vec![32],
+                    bytes: inputs.llm_blk0.clone(),
+                },
+                SourceTensor {
+                    name: "blk.2.weight",
+                    ggml_type: GGMLType::Q8_0,
+                    dims: vec![32],
+                    bytes: inputs.llm_blk1.clone(),
+                },
+            ],
+        );
+
+        let error = export_ggufrs(
+            &inputs.dir.join("model.ggufrs"),
+            &inputs.llm,
+            None,
+            ExportOptions::default(),
+        )
+        .unwrap_err();
+
+        match error {
+            GgufrsError::InvalidFormat { context } => {
+                assert!(context.contains("outside block count 2"), "{context}")
+            }
+            other => panic!("expected InvalidFormat, got {other}"),
+        }
+    }
 
     fn read_u64_at(bytes: &[u8], offset: usize) -> u64 {
         u64::from_le_bytes(bytes[offset..offset + 8].try_into().unwrap())

--- a/RustModelInference/src/ggufrs.rs
+++ b/RustModelInference/src/ggufrs.rs
@@ -1837,11 +1837,17 @@ fn validate_index(superblock: &Superblock, index: &mut PackageIndex) -> Result<(
 impl GgufrsFile {
     pub fn open(path: impl AsRef<Path>) -> Result<Self, GgufrsError> {
         let path = path.as_ref().to_path_buf();
-        let mut file = File::open(&path).map_err(|source| GgufrsError::Io {
+        let file = File::open(&path).map_err(|source| GgufrsError::Io {
             operation: "open ggufrs",
             path: path.clone(),
             source,
         })?;
+        Self::from_file(file, path)
+    }
+
+    fn from_file(mut file: File, path: PathBuf) -> Result<Self, GgufrsError> {
+        file.seek(SeekFrom::Start(0))
+            .map_err(|source| io_error("seek to ggufrs start", &path, source))?;
         let file_len = file
             .metadata()
             .map_err(|source| GgufrsError::Io {
@@ -2346,6 +2352,7 @@ fn write_planned_package(
 static PENDING_OUTPUT_ID: AtomicU64 = AtomicU64::new(0);
 
 struct PendingOutput {
+    file: File,
     path: PathBuf,
     output: PathBuf,
     overwrite: bool,
@@ -2372,10 +2379,15 @@ impl PendingOutput {
         loop {
             let id = PENDING_OUTPUT_ID.fetch_add(1, Ordering::Relaxed);
             let path = parent.join(format!(".ggufrs-{}-{id}.tmp", std::process::id()));
-            match OpenOptions::new().create_new(true).write(true).open(&path) {
+            match OpenOptions::new()
+                .create_new(true)
+                .read(true)
+                .write(true)
+                .open(&path)
+            {
                 Ok(file) => {
-                    drop(file);
                     return Ok(Self {
+                        file,
                         path,
                         output: output.to_path_buf(),
                         overwrite,
@@ -2398,8 +2410,61 @@ impl PendingOutput {
         &self.path
     }
 
+    fn file_mut(&mut self) -> &mut File {
+        &mut self.file
+    }
+
+    #[cfg(unix)]
+    fn path_matches_file(&self) -> Result<bool, GgufrsError> {
+        use std::os::unix::fs::MetadataExt;
+
+        let file = self
+            .file
+            .metadata()
+            .map_err(|source| io_error("read temporary package identity", &self.path, source))?;
+        let path = std::fs::symlink_metadata(&self.path).map_err(|source| {
+            io_error("read temporary package path identity", &self.path, source)
+        })?;
+        Ok(file.dev() == path.dev() && file.ino() == path.ino())
+    }
+
+    #[cfg(windows)]
+    fn path_matches_file(&self) -> Result<bool, GgufrsError> {
+        use std::os::windows::fs::MetadataExt;
+
+        let file = self
+            .file
+            .metadata()
+            .map_err(|source| io_error("read temporary package identity", &self.path, source))?;
+        let path = std::fs::symlink_metadata(&self.path).map_err(|source| {
+            io_error("read temporary package path identity", &self.path, source)
+        })?;
+        Ok(file.volume_serial_number() == path.volume_serial_number()
+            && file.file_index() == path.file_index())
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    fn path_matches_file(&self) -> Result<bool, GgufrsError> {
+        Err(invalid(
+            "temporary package identity checks are unsupported on this platform",
+        ))
+    }
+
     fn publish(mut self) -> Result<(), GgufrsError> {
-        GgufrsFile::open(&self.path)?.verify_all()?;
+        self.file
+            .flush()
+            .map_err(|source| io_error("flush temporary package", &self.path, source))?;
+        let verification_file = self
+            .file
+            .try_clone()
+            .map_err(|source| io_error("clone temporary package handle", &self.path, source))?;
+        GgufrsFile::from_file(verification_file, self.path.clone())?.verify_all()?;
+        if !self.path_matches_file()? {
+            return Err(invalid(format!(
+                "temporary package identity changed: {}",
+                self.path.display()
+            )));
+        }
         if self.overwrite {
             std::fs::rename(&self.path, &self.output).map_err(|source| {
                 GgufrsError::UnsupportedPublish {
@@ -2447,7 +2512,7 @@ impl PendingOutput {
 
 impl Drop for PendingOutput {
     fn drop(&mut self) {
-        if !self.published {
+        if !self.published && self.path_matches_file().unwrap_or(false) {
             let _ = std::fs::remove_file(&self.path);
         }
     }
@@ -2469,18 +2534,9 @@ pub fn export_ggufrs(
         sources.push(load_export_source(ComponentRole::Mmproj, path)?);
     }
     let mut plan = plan_export(&sources)?;
-    let pending = PendingOutput::create(output, options.overwrite)?;
-    let mut file = OpenOptions::new()
-        .write(true)
-        .truncate(true)
-        .open(pending.path())
-        .map_err(|source| GgufrsError::Io {
-            operation: "open temporary package",
-            path: pending.path().to_path_buf(),
-            source,
-        })?;
-    write_planned_package(&mut file, pending.path(), &sources, &mut plan)?;
-    drop(file);
+    let mut pending = PendingOutput::create(output, options.overwrite)?;
+    let pending_path = pending.path().to_path_buf();
+    write_planned_package(pending.file_mut(), &pending_path, &sources, &mut plan)?;
     pending.publish()
 }
 
@@ -3168,6 +3224,40 @@ mod tests {
         assert!(!output.exists());
         assert!(inputs.llm.exists());
         assert!(inputs.mmproj.exists());
+    }
+
+    #[test]
+    fn replaced_temp_path_cannot_truncate_or_publish_an_unrelated_inode() {
+        let inputs = test_support::test_gguf_pair();
+        let output = inputs.dir.join("model.ggufrs");
+        let unrelated = inputs.dir.join("unrelated.ggufrs");
+        let unrelated_bytes = test_support::package_fixture_bytes();
+        std::fs::write(&unrelated, &unrelated_bytes).unwrap();
+
+        let mut temp = PendingOutput::create(&output, false).unwrap();
+        let temp_path = temp.path().to_path_buf();
+        std::fs::remove_file(&temp_path).unwrap();
+        std::fs::hard_link(&unrelated, &temp_path).unwrap();
+
+        temp.file_mut()
+            .write_all(&test_support::package_fixture_bytes())
+            .unwrap();
+        assert_eq!(std::fs::read(&unrelated).unwrap(), unrelated_bytes);
+
+        let error = temp.publish().unwrap_err();
+
+        match error {
+            GgufrsError::InvalidFormat { context } => {
+                assert!(
+                    context.contains("temporary package identity changed"),
+                    "{context}"
+                )
+            }
+            other => panic!("expected InvalidFormat, got {other}"),
+        }
+        assert!(!output.exists());
+        assert_eq!(std::fs::read(&unrelated).unwrap(), unrelated_bytes);
+        assert_eq!(std::fs::read(&temp_path).unwrap(), unrelated_bytes);
     }
 
     #[test]

--- a/RustModelInference/src/ggufrs.rs
+++ b/RustModelInference/src/ggufrs.rs
@@ -1146,6 +1146,15 @@ fn parse_index(superblock: &Superblock, tables: &IndexTables) -> Result<PackageI
         let name = reader
             .read_string()
             .map_err(|message| invalid(format!("{context}: {message}")))?;
+        let canonical_name = match role {
+            ComponentRole::Llm => "llm",
+            ComponentRole::Mmproj => "mmproj",
+        };
+        if name != canonical_name {
+            return Err(invalid(format!(
+                "{context}: role {role:?} requires canonical name {canonical_name}, got {name}"
+            )));
+        }
         let metadata_start = reader
             .read_u32()
             .map_err(|message| invalid(format!("{context}: {message}")))?;
@@ -3517,10 +3526,12 @@ mod tests {
         .unwrap_err();
 
         match error {
-            GgufrsError::InvalidFormat { context } => {
-                assert!(context.contains("metadata array"), "{context}")
-            }
-            other => panic!("expected InvalidFormat, got {other}"),
+            GgufrsError::SourceGguf {
+                role: ComponentRole::Llm,
+                message,
+                ..
+            } => assert_eq!(message, "Nested metadata arrays are not supported"),
+            other => panic!("expected LLM SourceGguf, got {other}"),
         }
     }
 
@@ -3721,6 +3732,17 @@ mod tests {
         let mut bytes = test_support::package_fixture_bytes();
         bytes[SUPERBLOCK_LEN - 1] = 1;
         assert_invalid(bytes, "reserved superblock bytes must be zero");
+    }
+
+    #[test]
+    fn rejects_noncanonical_component_name_for_role() {
+        let mut bytes = test_support::package_fixture_bytes();
+        let component_table = read_u64_at(&bytes, 40) as usize;
+        bytes[component_table + 16..component_table + 19].copy_from_slice(b"bad");
+        assert_invalid(
+            bytes,
+            "component 0: role Llm requires canonical name llm, got bad",
+        );
     }
 
     #[test]

--- a/RustModelInference/src/lib.rs
+++ b/RustModelInference/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod clip_config;
+pub mod ggufrs;
 pub mod memory;
 pub mod model;
 pub mod ops;
@@ -15,6 +16,10 @@ pub mod traits;
 pub mod vision;
 
 pub use clip_config::{ClipVisionConfig, Qwen35Config};
+pub use ggufrs::{
+    open_model_source, ComponentInfo, ComponentRole, GgufrsError, GgufrsFile, LoadedComponent,
+    SegmentKind, GGUFRS_SEGMENT_ALIGNMENT, GGUFRS_VERSION,
+};
 pub use memory::{BlockAllocator, KVCacheView, MemoryArena, PagedKVBlock};
 pub use model::{
     model_config_from_source, GGMLType, GGUFLoader, MetaValue, MetaValueType, ModelGraph,

--- a/RustModelInference/src/lib.rs
+++ b/RustModelInference/src/lib.rs
@@ -17,7 +17,8 @@ pub mod vision;
 pub use clip_config::{ClipVisionConfig, Qwen35Config};
 pub use memory::{BlockAllocator, KVCacheView, MemoryArena, PagedKVBlock};
 pub use model::{
-    GGMLType, GGUFLoader, MetaValue, MetaValueType, ModelGraph, QuantizedLinear, TensorInfo,
+    model_config_from_source, GGMLType, GGUFLoader, MetaValue, MetaValueType, ModelGraph,
+    QuantizedLinear, TensorInfo, TensorSource,
 };
 pub use ops::*;
 pub use prompt::{

--- a/RustModelInference/src/lib.rs
+++ b/RustModelInference/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod clip_config;
 pub mod ggufrs;
+pub mod load_plan;
 pub mod memory;
 pub mod model;
 pub mod ops;
@@ -19,6 +20,10 @@ pub use clip_config::{ClipVisionConfig, Qwen35Config};
 pub use ggufrs::{
     export_ggufrs, open_model_source, ComponentInfo, ComponentRole, ExportOptions, GgufrsError,
     GgufrsFile, LoadedComponent, SegmentKind, GGUFRS_SEGMENT_ALIGNMENT, GGUFRS_VERSION,
+};
+pub use load_plan::{
+    build_load_plan, load_logical_cpu, LoadPlan, LogicalCpuDeviceLoad, LogicalCpuLoad,
+    LogicalCpuPlacement, LogicalDevice, Placement, PlacementPolicy, PlacementSlice,
 };
 pub use memory::{BlockAllocator, KVCacheView, MemoryArena, PagedKVBlock};
 pub use model::{

--- a/RustModelInference/src/lib.rs
+++ b/RustModelInference/src/lib.rs
@@ -17,8 +17,8 @@ pub mod vision;
 
 pub use clip_config::{ClipVisionConfig, Qwen35Config};
 pub use ggufrs::{
-    open_model_source, ComponentInfo, ComponentRole, GgufrsError, GgufrsFile, LoadedComponent,
-    SegmentKind, GGUFRS_SEGMENT_ALIGNMENT, GGUFRS_VERSION,
+    export_ggufrs, open_model_source, ComponentInfo, ComponentRole, ExportOptions, GgufrsError,
+    GgufrsFile, LoadedComponent, SegmentKind, GGUFRS_SEGMENT_ALIGNMENT, GGUFRS_VERSION,
 };
 pub use memory::{BlockAllocator, KVCacheView, MemoryArena, PagedKVBlock};
 pub use model::{

--- a/RustModelInference/src/load_plan.rs
+++ b/RustModelInference/src/load_plan.rs
@@ -1,0 +1,1226 @@
+use crate::ggufrs::{GgufrsError, GgufrsFile, MappedSegment, SegmentKind, TensorRecord};
+use std::collections::{BTreeMap, BTreeSet};
+use std::ops::Range;
+use std::sync::Arc;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogicalDevice {
+    pub id: String,
+    pub capacity: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlacementPolicy {
+    LayerSplit,
+    TensorSplit,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlacementSlice {
+    Whole,
+    Rows { start: u64, end: u64 },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Placement {
+    pub component_id: u32,
+    pub segment_id: u32,
+    pub tensor_name: String,
+    pub slice: PlacementSlice,
+    pub segment_byte_range: Range<u64>,
+    pub device_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoadPlan {
+    pub component_ids: Vec<u32>,
+    pub devices: Vec<LogicalDevice>,
+    pub primary_device: String,
+    pub policy: PlacementPolicy,
+    pub placements: Vec<Placement>,
+}
+
+fn invalid_plan(context: impl Into<String>) -> GgufrsError {
+    GgufrsError::InvalidPlan {
+        context: context.into(),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RowLayout {
+    row_count: u64,
+    row_bytes: u64,
+}
+
+fn row_layout(record: &TensorRecord) -> Result<RowLayout, GgufrsError> {
+    let row_elements = *record
+        .info
+        .dims
+        .first()
+        .ok_or_else(|| invalid_plan(format!("{} has rank zero", record.info.name)))?;
+    let row_count = record.info.dims[1..]
+        .iter()
+        .try_fold(1u64, |count, dimension| count.checked_mul(*dimension))
+        .ok_or_else(|| invalid_plan(format!("{} row count overflow", record.info.name)))?;
+    let (block_elements, block_bytes) = record.info.ggml_type.type_traits();
+    let block_elements = block_elements as u64;
+    if row_elements == 0 || row_elements % block_elements != 0 {
+        return Err(GgufrsError::UnsplittableTensor {
+            component_id: record.component_id,
+            tensor: record.info.name.clone(),
+            row_bytes: 0,
+            remaining: Vec::new(),
+            reason: "row element count is not divisible by quantization block size".into(),
+        });
+    }
+    let row_bytes = row_elements
+        .checked_div(block_elements)
+        .and_then(|blocks| blocks.checked_mul(block_bytes as u64))
+        .ok_or_else(|| invalid_plan(format!("{} row size overflow", record.info.name)))?;
+    if row_count.checked_mul(row_bytes) != Some(record.byte_len) {
+        return Err(invalid_plan(format!(
+            "{} row layout does not match byte_len {}",
+            record.info.name, record.byte_len
+        )));
+    }
+    Ok(RowLayout {
+        row_count,
+        row_bytes,
+    })
+}
+
+fn device_index(devices: &[LogicalDevice], id: &str) -> Result<usize, GgufrsError> {
+    devices
+        .iter()
+        .position(|device| device.id == id)
+        .ok_or_else(|| invalid_plan(format!("unknown logical device {id:?}")))
+}
+
+fn checked_tensor_range(record: &TensorRecord) -> Result<Range<u64>, GgufrsError> {
+    let end = record
+        .segment_offset
+        .checked_add(record.byte_len)
+        .ok_or_else(|| {
+            invalid_plan(format!(
+                "component {} segment {} tensor {} byte range overflow",
+                record.component_id, record.segment_id, record.info.name
+            ))
+        })?;
+    Ok(record.segment_offset..end)
+}
+
+fn validate_devices(devices: &[LogicalDevice], primary_device: &str) -> Result<usize, GgufrsError> {
+    if devices.is_empty() {
+        return Err(invalid_plan(
+            "load plan requires at least one logical device",
+        ));
+    }
+    let mut ids = BTreeSet::new();
+    for device in devices {
+        if device.id.is_empty() {
+            return Err(invalid_plan("logical device id must not be empty"));
+        }
+        if !ids.insert(device.id.as_str()) {
+            return Err(invalid_plan(format!(
+                "duplicate logical device id {:?}",
+                device.id
+            )));
+        }
+    }
+    device_index(devices, primary_device)
+}
+
+fn selected_components(
+    package: &GgufrsFile,
+    component_ids: &[u32],
+) -> Result<Vec<u32>, GgufrsError> {
+    let requested = component_ids.iter().copied().collect::<BTreeSet<_>>();
+    if requested.len() != component_ids.len() {
+        return Err(invalid_plan("selected component ids must be unique"));
+    }
+    let selected = package
+        .components()
+        .iter()
+        .filter(|component| requested.contains(&component.id))
+        .map(|component| component.id)
+        .collect::<Vec<_>>();
+    if selected.len() != requested.len() {
+        let unknown = requested
+            .iter()
+            .find(|id| !selected.contains(id))
+            .copied()
+            .unwrap();
+        return Err(invalid_plan(format!("unknown component id {unknown}")));
+    }
+    Ok(selected)
+}
+
+pub fn build_load_plan(
+    package: &GgufrsFile,
+    component_ids: &[u32],
+    devices: &[LogicalDevice],
+    primary_device: &str,
+    policy: PlacementPolicy,
+) -> Result<LoadPlan, GgufrsError> {
+    let primary = validate_devices(devices, primary_device)?;
+    let component_ids = selected_components(package, component_ids)?;
+    let selected = component_ids.iter().copied().collect::<BTreeSet<_>>();
+    let mut remaining = devices
+        .iter()
+        .map(|device| device.capacity)
+        .collect::<Vec<_>>();
+    let mut placements = Vec::new();
+
+    for record in package.tensors().iter().filter(|record| {
+        selected.contains(&record.component_id)
+            && package
+                .segment(record.segment_id)
+                .is_some_and(|segment| segment.kind != SegmentKind::Layer)
+    }) {
+        if record.byte_len > remaining[primary] {
+            return Err(GgufrsError::CapacityExceeded {
+                device_id: devices[primary].id.clone(),
+                required: record.byte_len,
+                available: remaining[primary],
+                context: format!(
+                    "component {} segment {} tensor {}",
+                    record.component_id, record.segment_id, record.info.name
+                ),
+            });
+        }
+        placements.push(Placement {
+            component_id: record.component_id,
+            segment_id: record.segment_id,
+            tensor_name: record.info.name.clone(),
+            slice: PlacementSlice::Whole,
+            segment_byte_range: checked_tensor_range(record)?,
+            device_id: devices[primary].id.clone(),
+        });
+        remaining[primary] = remaining[primary]
+            .checked_sub(record.byte_len)
+            .ok_or_else(|| invalid_plan("primary device capacity underflow"))?;
+    }
+
+    let mut layer_segments = component_ids
+        .iter()
+        .flat_map(|component_id| package.segments_for_component(*component_id))
+        .filter(|segment| segment.kind == SegmentKind::Layer)
+        .collect::<Vec<_>>();
+    layer_segments.sort_by_key(|segment| (segment.component_id, segment.layer, segment.id));
+
+    let mut current_device = 0usize;
+    match policy {
+        PlacementPolicy::LayerSplit => {
+            for segment in layer_segments {
+                let records = package.tensors_for_segment(segment.id).collect::<Vec<_>>();
+                let required = records.iter().try_fold(0u64, |sum, record| {
+                    sum.checked_add(record.byte_len)
+                        .ok_or_else(|| invalid_plan("layer payload overflow"))
+                })?;
+                while current_device < devices.len() && required > remaining[current_device] {
+                    current_device += 1;
+                }
+                if current_device == devices.len() {
+                    return Err(GgufrsError::CapacityExceeded {
+                        device_id: devices.last().unwrap().id.clone(),
+                        required,
+                        available: remaining.last().copied().unwrap_or(0),
+                        context: format!(
+                            "component {} segment {}",
+                            segment.component_id, segment.id
+                        ),
+                    });
+                }
+                for record in records {
+                    placements.push(Placement {
+                        component_id: record.component_id,
+                        segment_id: record.segment_id,
+                        tensor_name: record.info.name.clone(),
+                        slice: PlacementSlice::Whole,
+                        segment_byte_range: checked_tensor_range(record)?,
+                        device_id: devices[current_device].id.clone(),
+                    });
+                }
+                remaining[current_device] = remaining[current_device]
+                    .checked_sub(required)
+                    .ok_or_else(|| invalid_plan("logical device capacity underflow"))?;
+            }
+        }
+        PlacementPolicy::TensorSplit => {
+            for segment in layer_segments {
+                for record in package.tensors_for_segment(segment.id) {
+                    let layout = row_layout(record)?;
+                    let mut row_start = 0u64;
+                    while row_start < layout.row_count {
+                        while current_device < devices.len()
+                            && remaining[current_device] < layout.row_bytes
+                        {
+                            current_device += 1;
+                        }
+                        if current_device == devices.len() {
+                            return Err(GgufrsError::UnsplittableTensor {
+                                component_id: record.component_id,
+                                tensor: record.info.name.clone(),
+                                row_bytes: layout.row_bytes,
+                                remaining: devices
+                                    .iter()
+                                    .zip(&remaining)
+                                    .map(|(device, bytes)| (device.id.clone(), *bytes))
+                                    .collect(),
+                                reason: "no remaining device can hold one complete row".into(),
+                            });
+                        }
+                        let rows_here = (remaining[current_device] / layout.row_bytes)
+                            .min(layout.row_count - row_start);
+                        let row_end = row_start
+                            .checked_add(rows_here)
+                            .ok_or_else(|| invalid_plan("tensor row range overflow"))?;
+                        let start_delta =
+                            row_start.checked_mul(layout.row_bytes).ok_or_else(|| {
+                                invalid_plan(format!(
+                                    "{} row byte offset overflow",
+                                    record.info.name
+                                ))
+                            })?;
+                        let end_delta = row_end.checked_mul(layout.row_bytes).ok_or_else(|| {
+                            invalid_plan(format!("{} row byte end overflow", record.info.name))
+                        })?;
+                        let start =
+                            record
+                                .segment_offset
+                                .checked_add(start_delta)
+                                .ok_or_else(|| {
+                                    invalid_plan(format!(
+                                        "{} segment byte start overflow",
+                                        record.info.name
+                                    ))
+                                })?;
+                        let end =
+                            record
+                                .segment_offset
+                                .checked_add(end_delta)
+                                .ok_or_else(|| {
+                                    invalid_plan(format!(
+                                        "{} segment byte end overflow",
+                                        record.info.name
+                                    ))
+                                })?;
+                        placements.push(Placement {
+                            component_id: record.component_id,
+                            segment_id: record.segment_id,
+                            tensor_name: record.info.name.clone(),
+                            slice: if row_start == 0 && row_end == layout.row_count {
+                                PlacementSlice::Whole
+                            } else {
+                                PlacementSlice::Rows {
+                                    start: row_start,
+                                    end: row_end,
+                                }
+                            },
+                            segment_byte_range: start..end,
+                            device_id: devices[current_device].id.clone(),
+                        });
+                        let used = rows_here.checked_mul(layout.row_bytes).ok_or_else(|| {
+                            invalid_plan(format!(
+                                "{} placement byte size overflow",
+                                record.info.name
+                            ))
+                        })?;
+                        remaining[current_device] = remaining[current_device]
+                            .checked_sub(used)
+                            .ok_or_else(|| invalid_plan("logical device capacity underflow"))?;
+                        row_start = row_end;
+                    }
+                }
+            }
+        }
+    }
+    let plan = LoadPlan {
+        component_ids,
+        devices: devices.to_vec(),
+        primary_device: primary_device.into(),
+        policy,
+        placements,
+    };
+    plan.validate(package)?;
+    Ok(plan)
+}
+
+impl LoadPlan {
+    pub fn validate(&self, package: &GgufrsFile) -> Result<(), GgufrsError> {
+        validate_devices(&self.devices, &self.primary_device)?;
+        if selected_components(package, &self.component_ids)? != self.component_ids {
+            return Err(invalid_plan("component ids are not in package order"));
+        }
+        let selected = self.component_ids.iter().copied().collect::<BTreeSet<_>>();
+        for placement in &self.placements {
+            if !selected.contains(&placement.component_id) {
+                return Err(invalid_plan(format!(
+                    "placement references unselected component {}",
+                    placement.component_id
+                )));
+            }
+            device_index(&self.devices, &placement.device_id)?;
+            let record = package
+                .tensors()
+                .iter()
+                .find(|record| {
+                    record.component_id == placement.component_id
+                        && record.segment_id == placement.segment_id
+                        && record.info.name == placement.tensor_name
+                })
+                .ok_or_else(|| {
+                    invalid_plan(format!(
+                        "placement references unknown component {} segment {} tensor {}",
+                        placement.component_id, placement.segment_id, placement.tensor_name
+                    ))
+                })?;
+            let tensor_range = checked_tensor_range(record)?;
+            if placement.segment_byte_range.start > placement.segment_byte_range.end
+                || placement.segment_byte_range.start < tensor_range.start
+                || placement.segment_byte_range.end > tensor_range.end
+            {
+                return Err(invalid_plan(format!(
+                    "component {} segment {} tensor {} placement range {:?} is outside {:?}",
+                    placement.component_id,
+                    placement.segment_id,
+                    placement.tensor_name,
+                    placement.segment_byte_range,
+                    tensor_range
+                )));
+            }
+        }
+
+        let mut layer_devices = BTreeMap::<u32, String>::new();
+        for record in package
+            .tensors()
+            .iter()
+            .filter(|record| selected.contains(&record.component_id))
+        {
+            let segment = package.segment(record.segment_id).ok_or_else(|| {
+                invalid_plan(format!(
+                    "component {} tensor {} references unknown segment {}",
+                    record.component_id, record.info.name, record.segment_id
+                ))
+            })?;
+            let layout = row_layout(record)?;
+            let tensor_range = checked_tensor_range(record)?;
+            let mut row_ranges = Vec::<Range<u64>>::new();
+            for placement in self.placements.iter().filter(|placement| {
+                placement.component_id == record.component_id
+                    && placement.segment_id == record.segment_id
+                    && placement.tensor_name == record.info.name
+            }) {
+                if segment.kind != SegmentKind::Layer && placement.device_id != self.primary_device
+                {
+                    return Err(invalid_plan(format!(
+                        "component {} segment {} tensor {} must be on primary device {:?}",
+                        record.component_id,
+                        record.segment_id,
+                        record.info.name,
+                        self.primary_device
+                    )));
+                }
+                if self.policy == PlacementPolicy::LayerSplit
+                    && placement.slice != PlacementSlice::Whole
+                {
+                    return Err(invalid_plan(format!(
+                        "LayerSplit placement for component {} segment {} tensor {} is not whole",
+                        record.component_id, record.segment_id, record.info.name
+                    )));
+                }
+                if self.policy == PlacementPolicy::LayerSplit && segment.kind == SegmentKind::Layer
+                {
+                    if let Some(device_id) = layer_devices.get(&segment.id) {
+                        if device_id != &placement.device_id {
+                            return Err(invalid_plan(format!(
+                                "component {} layer segment {} spans devices {:?} and {:?}",
+                                segment.component_id, segment.id, device_id, placement.device_id
+                            )));
+                        }
+                    } else {
+                        layer_devices.insert(segment.id, placement.device_id.clone());
+                    }
+                }
+
+                let rows = match placement.slice {
+                    PlacementSlice::Whole => {
+                        if placement.segment_byte_range != tensor_range {
+                            return Err(invalid_plan(format!(
+                                "whole placement for component {} segment {} tensor {} has byte range {:?}, expected {:?}",
+                                record.component_id,
+                                record.segment_id,
+                                record.info.name,
+                                placement.segment_byte_range,
+                                tensor_range
+                            )));
+                        }
+                        0..layout.row_count
+                    }
+                    PlacementSlice::Rows { start, end } => {
+                        if start >= end || end > layout.row_count {
+                            return Err(invalid_plan(format!(
+                                "component {} segment {} tensor {} has invalid row range {start}..{end} of {}",
+                                record.component_id,
+                                record.segment_id,
+                                record.info.name,
+                                layout.row_count
+                            )));
+                        }
+                        let expected_start = start
+                            .checked_mul(layout.row_bytes)
+                            .and_then(|offset| record.segment_offset.checked_add(offset))
+                            .ok_or_else(|| {
+                                invalid_plan(format!(
+                                    "{} row placement start overflow",
+                                    record.info.name
+                                ))
+                            })?;
+                        let expected_end = end
+                            .checked_mul(layout.row_bytes)
+                            .and_then(|offset| record.segment_offset.checked_add(offset))
+                            .ok_or_else(|| {
+                                invalid_plan(format!(
+                                    "{} row placement end overflow",
+                                    record.info.name
+                                ))
+                            })?;
+                        if placement.segment_byte_range != (expected_start..expected_end) {
+                            return Err(invalid_plan(format!(
+                                "component {} segment {} tensor {} row range {start}..{end} has byte range {:?}, expected {:?}",
+                                record.component_id,
+                                record.segment_id,
+                                record.info.name,
+                                placement.segment_byte_range,
+                                expected_start..expected_end
+                            )));
+                        }
+                        start..end
+                    }
+                };
+                row_ranges.push(rows);
+            }
+            row_ranges.sort_unstable_by_key(|range| range.start);
+            let mut covered = 0u64;
+            for range in row_ranges {
+                if range.start != covered {
+                    return Err(invalid_plan(format!(
+                        "component {} segment {} tensor {} row coverage expected {covered}, got {}",
+                        record.component_id, record.segment_id, record.info.name, range.start
+                    )));
+                }
+                covered = range.end;
+            }
+            if covered != layout.row_count {
+                return Err(invalid_plan(format!(
+                    "component {} segment {} tensor {} row coverage ends at {covered}, expected {}",
+                    record.component_id, record.segment_id, record.info.name, layout.row_count
+                )));
+            }
+        }
+
+        if self.policy == PlacementPolicy::LayerSplit {
+            let mut previous_device = None;
+            for component_id in &self.component_ids {
+                for segment in package
+                    .segments_for_component(*component_id)
+                    .filter(|segment| segment.kind == SegmentKind::Layer)
+                {
+                    let device_id = layer_devices.get(&segment.id).ok_or_else(|| {
+                        invalid_plan(format!(
+                            "component {} layer segment {} has no assigned device",
+                            segment.component_id, segment.id
+                        ))
+                    })?;
+                    let index = device_index(&self.devices, device_id)?;
+                    if previous_device.is_some_and(|previous| index < previous) {
+                        return Err(invalid_plan(format!(
+                            "component {} layer segment {} backtracks to device {:?}",
+                            segment.component_id, segment.id, device_id
+                        )));
+                    }
+                    previous_device = Some(index);
+                }
+            }
+        }
+        for device in &self.devices {
+            let used = self.used_bytes(&device.id)?;
+            if used > device.capacity {
+                return Err(GgufrsError::CapacityExceeded {
+                    device_id: device.id.clone(),
+                    required: used,
+                    available: device.capacity,
+                    context: "load plan placements".into(),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    pub fn used_bytes(&self, device_id: &str) -> Result<u64, GgufrsError> {
+        self.placements
+            .iter()
+            .filter(|placement| placement.device_id == device_id)
+            .try_fold(0u64, |used, placement| {
+                let bytes = placement
+                    .segment_byte_range
+                    .end
+                    .checked_sub(placement.segment_byte_range.start)
+                    .ok_or_else(|| {
+                        invalid_plan(format!(
+                            "component {} segment {} tensor {} has reversed byte range {:?}",
+                            placement.component_id,
+                            placement.segment_id,
+                            placement.tensor_name,
+                            placement.segment_byte_range,
+                        ))
+                    })?;
+                used.checked_add(bytes).ok_or_else(|| {
+                    invalid_plan(format!("payload total overflow for device {device_id:?}"))
+                })
+            })
+    }
+}
+
+pub struct LogicalCpuPlacement {
+    pub placement: Placement,
+    mapping: Arc<MappedSegment>,
+}
+
+impl LogicalCpuPlacement {
+    pub fn bytes(&self) -> Option<&[u8]> {
+        (self.mapping.segment_id == self.placement.segment_id).then_some(())?;
+        let start = usize::try_from(self.placement.segment_byte_range.start).ok()?;
+        let end = usize::try_from(self.placement.segment_byte_range.end).ok()?;
+        self.mapping.bytes.get(start..end)
+    }
+}
+
+pub struct LogicalCpuDeviceLoad {
+    pub id: String,
+    pub placements: Vec<LogicalCpuPlacement>,
+}
+
+pub struct LogicalCpuLoad {
+    pub devices: Vec<LogicalCpuDeviceLoad>,
+}
+
+impl LogicalCpuLoad {
+    pub fn release_device(&mut self, device_id: &str) -> bool {
+        let Some(device) = self
+            .devices
+            .iter_mut()
+            .find(|device| device.id == device_id)
+        else {
+            return false;
+        };
+        let released = !device.placements.is_empty();
+        device.placements.clear();
+        released
+    }
+
+    pub fn release_component(&mut self, component_id: u32) -> usize {
+        let before = self
+            .devices
+            .iter()
+            .map(|device| device.placements.len())
+            .sum::<usize>();
+        for device in &mut self.devices {
+            device
+                .placements
+                .retain(|loaded| loaded.placement.component_id != component_id);
+        }
+        before
+            - self
+                .devices
+                .iter()
+                .map(|device| device.placements.len())
+                .sum::<usize>()
+    }
+}
+
+pub fn load_logical_cpu(
+    package: &GgufrsFile,
+    plan: &LoadPlan,
+) -> Result<LogicalCpuLoad, GgufrsError> {
+    plan.validate(package)?;
+    let mut mappings = BTreeMap::<u32, Arc<MappedSegment>>::new();
+    for placement in &plan.placements {
+        if !mappings.contains_key(&placement.segment_id) {
+            mappings.insert(
+                placement.segment_id,
+                package.map_segment_shared(placement.segment_id)?,
+            );
+        }
+    }
+    let mut devices = plan
+        .devices
+        .iter()
+        .map(|device| LogicalCpuDeviceLoad {
+            id: device.id.clone(),
+            placements: Vec::new(),
+        })
+        .collect::<Vec<_>>();
+    for placement in &plan.placements {
+        let target = devices
+            .iter_mut()
+            .find(|device| device.id == placement.device_id)
+            .ok_or_else(|| {
+                invalid_plan(format!(
+                    "placement for component {} tensor {} references unknown device {:?}",
+                    placement.component_id, placement.tensor_name, placement.device_id
+                ))
+            })?;
+        let mapping = mappings.get(&placement.segment_id).ok_or_else(|| {
+            invalid_plan(format!(
+                "placement for component {} tensor {} has no mapping for segment {}",
+                placement.component_id, placement.tensor_name, placement.segment_id
+            ))
+        })?;
+        target.placements.push(LogicalCpuPlacement {
+            placement: placement.clone(),
+            mapping: Arc::clone(mapping),
+        });
+    }
+    Ok(LogicalCpuLoad { devices })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ggufrs::{GgufrsFile, SegmentKind};
+    use crate::model::{GGMLType, TensorInfo};
+
+    struct ExportedFixture {
+        package: GgufrsFile,
+        #[allow(dead_code)]
+        inputs: crate::ggufrs::test_support::TestInputs,
+    }
+
+    fn exported_test_package() -> ExportedFixture {
+        let inputs = crate::ggufrs::test_support::test_gguf_pair();
+        let output = inputs.dir.join("load-plan.ggufrs");
+        crate::ggufrs::export_ggufrs(
+            &output,
+            &inputs.llm,
+            Some(&inputs.mmproj),
+            crate::ggufrs::ExportOptions::default(),
+        )
+        .unwrap();
+        let package = GgufrsFile::open(output).unwrap();
+        ExportedFixture { package, inputs }
+    }
+
+    #[test]
+    fn layer_split_keeps_layers_contiguous_and_shared_on_primary() {
+        let fixture = exported_test_package();
+        let package = &fixture.package;
+        let llm = package
+            .component_id(crate::ggufrs::ComponentRole::Llm)
+            .unwrap();
+        let mmproj = package
+            .component_id(crate::ggufrs::ComponentRole::Mmproj)
+            .unwrap();
+        let devices = vec![
+            LogicalDevice {
+                id: "cpu0".into(),
+                capacity: 354,
+            },
+            LogicalDevice {
+                id: "cpu1".into(),
+                capacity: 34,
+            },
+        ];
+        let plan = build_load_plan(
+            package,
+            &[llm, mmproj],
+            &devices,
+            "cpu0",
+            PlacementPolicy::LayerSplit,
+        )
+        .unwrap();
+        plan.validate(package).unwrap();
+        assert_eq!(
+            plan,
+            build_load_plan(
+                package,
+                &[llm, mmproj],
+                &devices,
+                "cpu0",
+                PlacementPolicy::LayerSplit,
+            )
+            .unwrap()
+        );
+
+        for placement in &plan.placements {
+            let segment = package.segment(placement.segment_id).unwrap();
+            if segment.kind != SegmentKind::Layer || placement.component_id == mmproj {
+                assert_eq!(placement.device_id, "cpu0");
+            }
+        }
+        let layer_devices: Vec<&str> = package
+            .segments_for_component(llm)
+            .filter(|segment| segment.kind == SegmentKind::Layer)
+            .map(|segment| {
+                plan.placements
+                    .iter()
+                    .find(|placement| placement.segment_id == segment.id)
+                    .unwrap()
+                    .device_id
+                    .as_str()
+            })
+            .collect();
+        assert_eq!(layer_devices, vec!["cpu0", "cpu1"]);
+        assert_eq!(plan.used_bytes("cpu0").unwrap(), 354);
+        assert_eq!(plan.used_bytes("cpu1").unwrap(), 34);
+    }
+
+    #[test]
+    fn tensor_split_uses_only_complete_quantized_rows() {
+        let fixture = crate::ggufrs::test_support::test_q8_row_package(4, 32);
+        let devices = vec![
+            LogicalDevice {
+                id: "cpu0".into(),
+                capacity: 196,
+            },
+            LogicalDevice {
+                id: "cpu1".into(),
+                capacity: 68,
+            },
+        ];
+        let plan = build_load_plan(
+            &fixture.package,
+            &[fixture.llm_component],
+            &devices,
+            "cpu0",
+            PlacementPolicy::TensorSplit,
+        )
+        .unwrap();
+        plan.validate(&fixture.package).unwrap();
+        let rows: Vec<&Placement> = plan
+            .placements
+            .iter()
+            .filter(|placement| placement.tensor_name == "blk.0.weight")
+            .collect();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].slice, PlacementSlice::Rows { start: 0, end: 2 });
+        assert_eq!(rows[1].slice, PlacementSlice::Rows { start: 2, end: 4 });
+        assert!(rows.iter().all(|placement| {
+            (placement.segment_byte_range.end - placement.segment_byte_range.start) % 34 == 0
+        }));
+    }
+
+    #[test]
+    fn row_layout_rejects_incomplete_quantization_blocks() {
+        let record = TensorRecord {
+            component_id: 0,
+            segment_id: 0,
+            info: TensorInfo {
+                name: "bad".into(),
+                dims: vec![31, 2],
+                ggml_type: GGMLType::Q8_0,
+                offset: 0,
+            },
+            segment_offset: 0,
+            byte_len: 68,
+        };
+        assert!(matches!(
+            row_layout(&record),
+            Err(GgufrsError::UnsplittableTensor { .. })
+        ));
+    }
+
+    #[test]
+    fn tensor_split_keeps_rank_one_layer_tensors_whole() {
+        let fixture = exported_test_package();
+        let package = &fixture.package;
+        let llm = package
+            .component_id(crate::ggufrs::ComponentRole::Llm)
+            .unwrap();
+        let devices = vec![
+            LogicalDevice {
+                id: "cpu0".into(),
+                capacity: 128,
+            },
+            LogicalDevice {
+                id: "cpu1".into(),
+                capacity: 68,
+            },
+        ];
+        let plan = build_load_plan(
+            package,
+            &[llm],
+            &devices,
+            "cpu0",
+            PlacementPolicy::TensorSplit,
+        )
+        .unwrap();
+        let layers: Vec<&Placement> = plan
+            .placements
+            .iter()
+            .filter(|placement| placement.tensor_name.starts_with("blk."))
+            .collect();
+        assert_eq!(layers.len(), 2);
+        assert!(layers.iter().all(|placement| {
+            placement.device_id == "cpu1" && placement.slice == PlacementSlice::Whole
+        }));
+    }
+
+    #[test]
+    fn planning_reports_capacity_and_row_failures() {
+        let fixture = exported_test_package();
+        let package = &fixture.package;
+        let llm = package
+            .component_id(crate::ggufrs::ComponentRole::Llm)
+            .unwrap();
+        let too_small = vec![LogicalDevice {
+            id: "cpu0".into(),
+            capacity: 127,
+        }];
+        assert!(matches!(
+            build_load_plan(
+                package,
+                &[llm],
+                &too_small,
+                "cpu0",
+                PlacementPolicy::LayerSplit,
+            ),
+            Err(GgufrsError::CapacityExceeded { .. })
+        ));
+
+        let fixture = crate::ggufrs::test_support::test_q8_row_package(2, 64);
+        let devices = vec![
+            LogicalDevice {
+                id: "cpu0".into(),
+                capacity: 128,
+            },
+            LogicalDevice {
+                id: "cpu1".into(),
+                capacity: 34,
+            },
+        ];
+        assert!(matches!(
+            build_load_plan(
+                &fixture.package,
+                &[fixture.llm_component],
+                &devices,
+                "cpu0",
+                PlacementPolicy::TensorSplit,
+            ),
+            Err(GgufrsError::UnsplittableTensor { row_bytes: 68, .. })
+        ));
+    }
+
+    #[test]
+    fn planning_rejects_ambiguous_devices_and_components() {
+        let fixture = exported_test_package();
+        let package = &fixture.package;
+        let llm = package
+            .component_id(crate::ggufrs::ComponentRole::Llm)
+            .unwrap();
+        let duplicate = vec![
+            LogicalDevice {
+                id: "cpu".into(),
+                capacity: 1024,
+            },
+            LogicalDevice {
+                id: "cpu".into(),
+                capacity: 1024,
+            },
+        ];
+        assert!(build_load_plan(
+            package,
+            &[llm],
+            &duplicate,
+            "cpu",
+            PlacementPolicy::LayerSplit,
+        )
+        .is_err());
+        let valid = vec![LogicalDevice {
+            id: "cpu".into(),
+            capacity: 1024,
+        }];
+        assert!(build_load_plan(
+            package,
+            &[llm],
+            &valid,
+            "missing",
+            PlacementPolicy::LayerSplit,
+        )
+        .is_err());
+        assert!(build_load_plan(
+            package,
+            &[llm, llm],
+            &valid,
+            "cpu",
+            PlacementPolicy::LayerSplit,
+        )
+        .is_err());
+        assert!(build_load_plan(
+            package,
+            &[u32::MAX],
+            &valid,
+            "cpu",
+            PlacementPolicy::LayerSplit,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn validation_rejects_missing_overlapping_or_misaligned_rows() {
+        let fixture = crate::ggufrs::test_support::test_q8_row_package(4, 32);
+        let devices = vec![
+            LogicalDevice {
+                id: "cpu0".into(),
+                capacity: 196,
+            },
+            LogicalDevice {
+                id: "cpu1".into(),
+                capacity: 68,
+            },
+        ];
+        let plan = build_load_plan(
+            &fixture.package,
+            &[fixture.llm_component],
+            &devices,
+            "cpu0",
+            PlacementPolicy::TensorSplit,
+        )
+        .unwrap();
+
+        let mut missing = plan.clone();
+        missing.placements.pop();
+        assert!(missing.validate(&fixture.package).is_err());
+
+        let mut overlap = plan.clone();
+        let second = overlap
+            .placements
+            .iter_mut()
+            .find(|placement| {
+                placement.tensor_name == "blk.0.weight"
+                    && placement.slice == PlacementSlice::Rows { start: 2, end: 4 }
+            })
+            .unwrap();
+        second.slice = PlacementSlice::Rows { start: 1, end: 4 };
+        assert!(overlap.validate(&fixture.package).is_err());
+
+        let mut misaligned = plan;
+        let row = misaligned
+            .placements
+            .iter_mut()
+            .find(|placement| placement.tensor_name == "blk.0.weight")
+            .unwrap();
+        row.segment_byte_range.end -= 1;
+        assert!(misaligned.validate(&fixture.package).is_err());
+    }
+
+    #[test]
+    fn validation_rejects_forged_tensor_ownership_device_and_capacity() {
+        let fixture = exported_test_package();
+        let package = &fixture.package;
+        let llm = package
+            .component_id(crate::ggufrs::ComponentRole::Llm)
+            .unwrap();
+        let mmproj = package
+            .component_id(crate::ggufrs::ComponentRole::Mmproj)
+            .unwrap();
+        let devices = vec![
+            LogicalDevice {
+                id: "cpu0".into(),
+                capacity: 1024,
+            },
+            LogicalDevice {
+                id: "cpu1".into(),
+                capacity: 1024,
+            },
+        ];
+        let plan = build_load_plan(
+            package,
+            &[llm, mmproj],
+            &devices,
+            "cpu0",
+            PlacementPolicy::LayerSplit,
+        )
+        .unwrap();
+
+        let mut wrong_owner = plan.clone();
+        wrong_owner
+            .placements
+            .iter_mut()
+            .find(|placement| placement.component_id == mmproj)
+            .unwrap()
+            .device_id = "cpu1".into();
+        assert!(wrong_owner.validate(package).is_err());
+
+        let mut forged = plan.clone();
+        forged.devices[0].capacity = u64::MAX;
+        let mut extra = forged.placements[0].clone();
+        extra.tensor_name = "not-a-package-tensor".into();
+        forged.placements.push(extra);
+        assert!(forged.validate(package).is_err());
+
+        let mut unknown_device = plan.clone();
+        unknown_device.placements[0].device_id = "missing".into();
+        assert!(unknown_device.validate(package).is_err());
+
+        let mut over_capacity = plan;
+        over_capacity.devices[0].capacity = 1;
+        assert!(matches!(
+            over_capacity.validate(package),
+            Err(GgufrsError::CapacityExceeded { .. })
+        ));
+    }
+
+    #[test]
+    fn layer_split_validation_requires_whole_single_device_layers() {
+        let fixture = crate::ggufrs::test_support::test_q8_row_package(4, 32);
+        let devices = vec![
+            LogicalDevice {
+                id: "cpu0".into(),
+                capacity: 196,
+            },
+            LogicalDevice {
+                id: "cpu1".into(),
+                capacity: 68,
+            },
+        ];
+        let mut plan = build_load_plan(
+            &fixture.package,
+            &[fixture.llm_component],
+            &devices,
+            "cpu0",
+            PlacementPolicy::TensorSplit,
+        )
+        .unwrap();
+        plan.policy = PlacementPolicy::LayerSplit;
+        assert!(plan.validate(&fixture.package).is_err());
+    }
+
+    #[test]
+    fn layer_split_validation_rejects_device_order_backtracking() {
+        let fixture = exported_test_package();
+        let package = &fixture.package;
+        let llm = package
+            .component_id(crate::ggufrs::ComponentRole::Llm)
+            .unwrap();
+        let devices = vec![
+            LogicalDevice {
+                id: "cpu0".into(),
+                capacity: 1024,
+            },
+            LogicalDevice {
+                id: "cpu1".into(),
+                capacity: 1024,
+            },
+        ];
+        let mut plan = build_load_plan(
+            package,
+            &[llm],
+            &devices,
+            "cpu0",
+            PlacementPolicy::LayerSplit,
+        )
+        .unwrap();
+        plan.placements
+            .iter_mut()
+            .find(|placement| placement.tensor_name == "blk.0.weight")
+            .unwrap()
+            .device_id = "cpu1".into();
+        assert!(plan.validate(package).is_err());
+    }
+
+    #[test]
+    fn logical_cpu_shares_split_segment_mapping_until_each_device_releases() {
+        let fixture = crate::ggufrs::test_support::test_q8_row_package(4, 32);
+        let devices = vec![
+            LogicalDevice {
+                id: "cpu0".into(),
+                capacity: 196,
+            },
+            LogicalDevice {
+                id: "cpu1".into(),
+                capacity: 68,
+            },
+        ];
+        let plan = build_load_plan(
+            &fixture.package,
+            &[fixture.llm_component],
+            &devices,
+            "cpu0",
+            PlacementPolicy::TensorSplit,
+        )
+        .unwrap();
+        let mut load = load_logical_cpu(&fixture.package, &plan).unwrap();
+        let weak = {
+            let first = load.devices[0]
+                .placements
+                .iter()
+                .find(|loaded| loaded.placement.tensor_name == "blk.0.weight")
+                .unwrap();
+            assert_eq!(first.bytes().unwrap(), &[0x22; 68]);
+            assert!(load.devices[1]
+                .placements
+                .iter()
+                .any(|loaded| Arc::ptr_eq(&first.mapping, &loaded.mapping)));
+            Arc::downgrade(&first.mapping)
+        };
+        assert!(!load.release_device("missing"));
+        assert!(load.release_device("cpu0"));
+        assert!(weak.upgrade().is_some());
+        assert!(!load.release_device("cpu0"));
+        assert!(load.release_device("cpu1"));
+        assert!(weak.upgrade().is_none());
+    }
+
+    #[test]
+    fn logical_cpu_releases_one_component_without_invalidating_another() {
+        let fixture = exported_test_package();
+        let package = &fixture.package;
+        let llm = package
+            .component_id(crate::ggufrs::ComponentRole::Llm)
+            .unwrap();
+        let mmproj = package
+            .component_id(crate::ggufrs::ComponentRole::Mmproj)
+            .unwrap();
+        let devices = vec![LogicalDevice {
+            id: "cpu0".into(),
+            capacity: 388,
+        }];
+        let plan = build_load_plan(
+            package,
+            &[llm, mmproj],
+            &devices,
+            "cpu0",
+            PlacementPolicy::LayerSplit,
+        )
+        .unwrap();
+        let mut load = load_logical_cpu(package, &plan).unwrap();
+        assert_eq!(
+            load.devices[0]
+                .placements
+                .iter()
+                .find(|loaded| loaded.placement.tensor_name == "mm.0.weight")
+                .unwrap()
+                .bytes()
+                .unwrap(),
+            fixture.inputs.mmproj_weight
+        );
+
+        assert_eq!(load.release_component(mmproj), 3);
+        assert!(load.devices[0]
+            .placements
+            .iter()
+            .all(|loaded| loaded.placement.component_id == llm));
+        assert_eq!(
+            load.devices[0]
+                .placements
+                .iter()
+                .find(|loaded| loaded.placement.tensor_name == "token_embd.weight")
+                .unwrap()
+                .bytes()
+                .unwrap(),
+            fixture.inputs.llm_shared
+        );
+        assert_eq!(load.release_component(mmproj), 0);
+    }
+}

--- a/RustModelInference/src/main.rs
+++ b/RustModelInference/src/main.rs
@@ -115,14 +115,21 @@ mod cli_tests {
             bytes: bytes.repeat(32),
         };
         let weight = EmbeddingWeight::load(&source, "weight", 32, 1).unwrap();
+        let mut scratch = EmbeddingActivationScratch::new(32);
+        let activation = scratch.prepare(&weight, &[0.1; 32]).unwrap();
         let mut output = [0.0];
 
-        weight.matmul(&[0.1; 32], &mut output).unwrap();
+        weight.matmul_prepared(&activation, &mut output).unwrap();
 
-        #[cfg(target_arch = "aarch64")]
-        assert_eq!(output[0].to_bits(), 0x3ea3_c000);
-        #[cfg(not(target_arch = "aarch64"))]
-        assert_eq!(output[0].to_bits(), 0x3ea3_c28e);
+        #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+        let expected = if std::arch::is_aarch64_feature_detected!("fp16") {
+            0x3ea3_c000
+        } else {
+            0x3ea3_c28e
+        };
+        #[cfg(not(all(target_arch = "aarch64", target_endian = "little")))]
+        let expected = 0x3ea3_c28e;
+        assert_eq!(output[0].to_bits(), expected);
     }
 
     #[test]
@@ -137,11 +144,49 @@ mod cli_tests {
             bytes: [half::f16::from_f32(1.0).to_bits().to_le_bytes().as_slice(), &[1; 32]].concat(),
         };
         let weight = EmbeddingWeight::load(&source, "weight", 32, 1).unwrap();
+        let mut scratch = EmbeddingActivationScratch::new(32);
+        let activation = scratch.prepare(&weight, &[1.0; 32]).unwrap();
         let mut output = [0.0];
 
-        weight.matmul(&[1.0; 32], &mut output).unwrap();
+        weight.matmul_prepared(&activation, &mut output).unwrap();
 
         assert_eq!(output, [31.998_047]);
+    }
+
+    #[test]
+    fn prepared_embedding_activation_is_reused_across_projections() {
+        let f16_bytes = half::f16::from_f32(1.0).to_bits().to_le_bytes().repeat(32);
+        let f16 = EmbeddingWeight {
+            bytes: &f16_bytes,
+            ggml_type: GGMLType::F16,
+            n_cols: 32,
+            n_rows: 1,
+        };
+        let q8_bytes = [
+            half::f16::from_f32(1.0).to_bits().to_le_bytes().as_slice(),
+            &[1; 32],
+        ]
+        .concat();
+        let q8 = EmbeddingWeight {
+            bytes: &q8_bytes,
+            ggml_type: GGMLType::Q8_0,
+            n_cols: 32,
+            n_rows: 1,
+        };
+        let mut scratch = EmbeddingActivationScratch::new(32);
+        let input = [1.0; 32];
+
+        let f16_activation = scratch.prepare(&f16, &input).unwrap();
+        let f16_ptr = f16_activation.f16.as_ptr();
+        f16.matmul_prepared(&f16_activation, &mut [0.0]).unwrap();
+        let f16_activation = scratch.prepare(&f16, &input).unwrap();
+        assert_eq!(f16_activation.f16.as_ptr(), f16_ptr);
+
+        let q8_activation = scratch.prepare(&q8, &input).unwrap();
+        let q8_ptr = q8_activation.q8.as_ptr();
+        q8.matmul_prepared(&q8_activation, &mut [0.0]).unwrap();
+        let q8_activation = scratch.prepare(&q8, &input).unwrap();
+        assert_eq!(q8_activation.q8.as_ptr(), q8_ptr);
     }
 
     #[test]
@@ -320,6 +365,7 @@ mod cli_tests {
             &mut [0.0; 32],
             &mut [0.0; 32],
             &mut [0.0; 32],
+            &mut EmbeddingActivationScratch::new(32),
         )
         .unwrap();
 
@@ -728,6 +774,62 @@ struct EmbeddingWeight<'a> {
     n_rows: usize,
 }
 
+struct EmbeddingActivationScratch {
+    f16: Vec<u16>,
+    q8: Vec<u8>,
+    scales: Vec<f32>,
+}
+
+struct EmbeddingActivation<'a> {
+    ggml_type: GGMLType,
+    n_cols: usize,
+    f16: &'a [u16],
+    q8: &'a [u8],
+    scales: &'a [f32],
+}
+
+impl EmbeddingActivationScratch {
+    fn new(max_cols: usize) -> Self {
+        Self {
+            f16: vec![0; max_cols],
+            q8: vec![0; max_cols],
+            scales: vec![0.0; max_cols.div_ceil(32)],
+        }
+    }
+
+    fn prepare<'a>(
+        &'a mut self,
+        weight: &EmbeddingWeight<'_>,
+        input: &[f32],
+    ) -> Result<EmbeddingActivation<'a>, String> {
+        if input.len() != weight.n_cols || input.len() > self.f16.len() {
+            return Err(format!(
+                "Embedding activation has {} values; expected {} (scratch capacity {})",
+                input.len(),
+                weight.n_cols,
+                self.f16.len()
+            ));
+        }
+        match weight.ggml_type {
+            GGMLType::F16 => f32_slice_to_f16(input, &mut self.f16[..input.len()]),
+            GGMLType::Q8_0 => quantize_q8_0_into(
+                input,
+                input.len(),
+                &mut self.q8[..input.len()],
+                &mut self.scales[..input.len() / 32],
+            ),
+            _ => unreachable!("EmbeddingWeight validates its type"),
+        }
+        Ok(EmbeddingActivation {
+            ggml_type: weight.ggml_type,
+            n_cols: input.len(),
+            f16: &self.f16[..input.len()],
+            q8: &self.q8[..input.len()],
+            scales: &self.scales[..input.len() / 32],
+        })
+    }
+}
+
 impl<'a> EmbeddingWeight<'a> {
     fn load(
         source: &'a dyn TensorSource,
@@ -806,45 +908,69 @@ impl<'a> EmbeddingWeight<'a> {
         Ok(())
     }
 
-    fn matmul(&self, input: &[f32], output: &mut [f32]) -> Result<(), String> {
-        if input.len() != self.n_cols || output.len() != self.n_rows {
+    fn matmul_prepared(
+        &self,
+        activation: &EmbeddingActivation<'_>,
+        output: &mut [f32],
+    ) -> Result<(), String> {
+        if activation.ggml_type != self.ggml_type
+            || activation.n_cols != self.n_cols
+            || output.len() != self.n_rows
+        {
             return Err(format!(
-                "Embedding matmul has input/output shape {}/{}; expected {}/{}",
-                input.len(),
+                "Embedding matmul has activation/output type {:?} shape {}/{}; expected {:?} {}/{}",
+                activation.ggml_type,
+                activation.n_cols,
                 output.len(),
+                self.ggml_type,
                 self.n_cols,
                 self.n_rows
             ));
         }
         match self.ggml_type {
             GGMLType::F16 => {
-                let input_f16: Vec<u16> = input.iter().copied().map(f32_to_f16).collect();
                 for (row, value) in output.iter_mut().enumerate() {
                     let offset = row * self.n_cols * 2;
                     *value = dot_f16_f16_bytes(
-                        &input_f16,
+                        activation.f16,
                         &self.bytes[offset..offset + self.n_cols * 2],
                         self.n_cols,
                     );
                 }
             }
-            GGMLType::Q8_0 => {
-                let mut input_q8 = vec![0u8; self.n_cols];
-                let mut input_scales = vec![0.0f32; self.n_cols / 32];
-                quantize_q8_0_into(input, self.n_cols, &mut input_q8, &mut input_scales);
-                matmul_q8_0_quantized(
-                    self.bytes,
-                    &input_q8,
-                    &input_scales,
-                    output,
-                    self.n_cols,
-                    self.n_rows,
-                );
-            }
+            GGMLType::Q8_0 => matmul_q8_0_quantized(
+                self.bytes,
+                activation.q8,
+                activation.scales,
+                output,
+                self.n_cols,
+                self.n_rows,
+            ),
             _ => unreachable!("EmbeddingWeight validates its type"),
         }
         Ok(())
     }
+}
+
+fn embedding_matmul_group(
+    input: &[f32],
+    projections: &mut [(&EmbeddingWeight<'_>, &mut [f32])],
+    scratch: &mut EmbeddingActivationScratch,
+) -> Result<(), String> {
+    for ggml_type in [GGMLType::F16, GGMLType::Q8_0] {
+        if let Some(index) = projections
+            .iter()
+            .position(|(weight, _)| weight.ggml_type == ggml_type)
+        {
+            let activation = scratch.prepare(projections[index].0, input)?;
+            for (weight, output) in projections.iter_mut() {
+                if weight.ggml_type == ggml_type {
+                    weight.matmul_prepared(&activation, output)?;
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 struct EmbeddingLayerWeights<'a> {
@@ -958,6 +1084,7 @@ fn apply_embedding_ffn_typed(
     gate_buf: &mut [f32],
     up_buf: &mut [f32],
     down_buf: &mut [f32],
+    activation_scratch: &mut EmbeddingActivationScratch,
 ) -> Result<(), String> {
     assert_eq!(hidden.len(), normed.len());
     assert!(n_embd > 0 && n_ff > 0);
@@ -970,12 +1097,19 @@ fn apply_embedding_ffn_typed(
         .chunks_exact(n_embd)
         .zip(hidden.chunks_exact_mut(n_embd))
     {
-        w_gate.matmul(input, gate_buf)?;
-        w_up.matmul(input, up_buf)?;
+        embedding_matmul_group(
+            input,
+            &mut [(w_gate, &mut *gate_buf), (w_up, &mut *up_buf)],
+            activation_scratch,
+        )?;
 
         silu_mul_inplace(gate_buf, up_buf);
 
-        w_down.matmul(up_buf, down_buf)?;
+        embedding_matmul_group(
+            up_buf,
+            &mut [(w_down, &mut *down_buf)],
+            activation_scratch,
+        )?;
 
         for index in 0..n_embd {
             residual[index] += down_buf[index];
@@ -1174,6 +1308,8 @@ fn run_embedding(
     let mut gate_buf = vec![0.0f32; n_ff];
     let mut up_buf = vec![0.0f32; n_ff];
     let mut down_buf = vec![0.0f32; n_embd];
+    let mut activation_scratch =
+        EmbeddingActivationScratch::new(n_embd.max(n_embd_q).max(n_ff));
     let max_n_padded = (n_tokens + 255) / 256 * 256;
     let mut scores = vec![0.0f32; max_n_padded];
     let mut values = vec![0.0f32; max_n_padded];
@@ -1211,9 +1347,12 @@ fn run_embedding(
             let k = &mut k_buf[t * n_embd_gqa..(t + 1) * n_embd_gqa];
             let v = &mut v_buf[t * n_embd_gqa..(t + 1) * n_embd_gqa];
 
-            lw.wq.matmul(x, q).unwrap_or_else(|error| panic!("Embedding Q matmul failed: {error}"));
-            lw.wk.matmul(x, k).unwrap_or_else(|error| panic!("Embedding K matmul failed: {error}"));
-            lw.wv.matmul(x, v).unwrap_or_else(|error| panic!("Embedding V matmul failed: {error}"));
+            embedding_matmul_group(
+                x,
+                &mut [(&lw.wq, q), (&lw.wk, k), (&lw.wv, v)],
+                &mut activation_scratch,
+            )
+            .unwrap_or_else(|error| panic!("Embedding Q/K/V matmul failed: {error}"));
         }
 
         if let (Some(qn), Some(kn)) = (&lw.q_norm, &lw.k_norm) {
@@ -1293,7 +1432,12 @@ fn run_embedding(
             let attn = &attn_out[t * n_embd_q..(t + 1) * n_embd_q];
             let proj = &mut attn_proj[t * n_embd..(t + 1) * n_embd];
 
-            lw.wo.matmul(attn, proj).unwrap_or_else(|error| panic!("Embedding output matmul failed: {error}"));
+            embedding_matmul_group(
+                attn,
+                &mut [(&lw.wo, proj)],
+                &mut activation_scratch,
+            )
+            .unwrap_or_else(|error| panic!("Embedding output matmul failed: {error}"));
         }
 
         for t in 0..n_tokens {
@@ -1324,6 +1468,7 @@ fn run_embedding(
             &mut gate_buf,
             &mut up_buf,
             &mut down_buf,
+            &mut activation_scratch,
         )
         .unwrap_or_else(|error| panic!("Embedding FFN failed: {error}"));
     }

--- a/RustModelInference/src/main.rs
+++ b/RustModelInference/src/main.rs
@@ -65,6 +65,139 @@ mod cli_tests {
     use std::collections::HashMap;
     use std::time::Duration;
 
+    struct TestTensorSource {
+        info: TensorInfo,
+        bytes: Vec<u8>,
+    }
+
+    impl TensorSource for TestTensorSource {
+        fn metadata(&self, _key: &str) -> Option<&MetaValue> {
+            None
+        }
+
+        fn tensor_info(&self, name: &str) -> Option<&TensorInfo> {
+            (name == self.info.name).then_some(&self.info)
+        }
+
+        fn tensor_slice(&self, name: &str) -> Option<&[u8]> {
+            (name == self.info.name).then_some(&self.bytes)
+        }
+    }
+
+    #[test]
+    fn f16_embedding_rows_decode_little_endian_half_values() {
+        let source = TestTensorSource {
+            info: TensorInfo {
+                name: "token_embd.weight".into(),
+                dims: vec![4, 1],
+                ggml_type: GGMLType::F16,
+                offset: 0,
+            },
+            bytes: [0x00, 0x3c, 0x00, 0xc0, 0x55, 0x35, 0x00, 0x00].to_vec(),
+        };
+
+        let weight = EmbeddingWeight::load(&source, "token_embd.weight", 4, 1).unwrap();
+        let mut row = [0.0; 4];
+        weight.get_row(0, &mut row).unwrap();
+        assert_eq!(row, [1.0, -2.0, 0.333_251_95, 0.0]);
+    }
+
+    #[test]
+    fn f16_embedding_matmul_uses_ggml_fp16_vector_accumulation() {
+        let bytes = half::f16::from_f32(0.1).to_bits().to_le_bytes();
+        let source = TestTensorSource {
+            info: TensorInfo {
+                name: "weight".into(),
+                dims: vec![32, 1],
+                ggml_type: GGMLType::F16,
+                offset: 0,
+            },
+            bytes: bytes.repeat(32),
+        };
+        let weight = EmbeddingWeight::load(&source, "weight", 32, 1).unwrap();
+        let mut output = [0.0];
+
+        weight.matmul(&[0.1; 32], &mut output).unwrap();
+
+        #[cfg(target_arch = "aarch64")]
+        assert_eq!(output[0].to_bits(), 0x3ea3_c000);
+        #[cfg(not(target_arch = "aarch64"))]
+        assert_eq!(output[0].to_bits(), 0x3ea3_c28e);
+    }
+
+    #[test]
+    fn q8_embedding_matmul_uses_the_existing_quantized_kernel() {
+        let source = TestTensorSource {
+            info: TensorInfo {
+                name: "weight".into(),
+                dims: vec![32, 1],
+                ggml_type: GGMLType::Q8_0,
+                offset: 0,
+            },
+            bytes: [half::f16::from_f32(1.0).to_bits().to_le_bytes().as_slice(), &[1; 32]].concat(),
+        };
+        let weight = EmbeddingWeight::load(&source, "weight", 32, 1).unwrap();
+        let mut output = [0.0];
+
+        weight.matmul(&[1.0; 32], &mut output).unwrap();
+
+        assert_eq!(output, [31.998_047]);
+    }
+
+    #[test]
+    fn embedding_weight_rejects_invalid_type_shape_length_and_row() {
+        let invalid_type = TestTensorSource {
+            info: TensorInfo {
+                name: "weight".into(),
+                dims: vec![4, 1],
+                ggml_type: GGMLType::F32,
+                offset: 0,
+            },
+            bytes: vec![0; 16],
+        };
+        assert!(EmbeddingWeight::load(&invalid_type, "weight", 4, 1)
+            .unwrap_err()
+            .contains("unsupported type"));
+
+        let wrong_shape = TestTensorSource {
+            info: TensorInfo {
+                name: "weight".into(),
+                dims: vec![2, 2],
+                ggml_type: GGMLType::F16,
+                offset: 0,
+            },
+            bytes: vec![0; 8],
+        };
+        assert!(EmbeddingWeight::load(&wrong_shape, "weight", 4, 1)
+            .unwrap_err()
+            .contains("shape"));
+
+        let wrong_length = TestTensorSource {
+            info: TensorInfo {
+                name: "weight".into(),
+                dims: vec![4, 1],
+                ggml_type: GGMLType::F16,
+                offset: 0,
+            },
+            bytes: vec![0; 7],
+        };
+        assert!(EmbeddingWeight::load(&wrong_length, "weight", 4, 1)
+            .unwrap_err()
+            .contains("expected 8"));
+
+        let valid = TestTensorSource {
+            info: TensorInfo {
+                name: "weight".into(),
+                dims: vec![4, 1],
+                ggml_type: GGMLType::F16,
+                offset: 0,
+            },
+            bytes: vec![0; 8],
+        };
+        let weight = EmbeddingWeight::load(&valid, "weight", 4, 1).unwrap();
+        assert!(weight.get_row(1, &mut [0.0; 4]).unwrap_err().contains("out of range"));
+    }
+
     #[test]
     fn embedding_output_accepts_only_summary_or_raw() {
         assert_eq!(
@@ -162,6 +295,12 @@ mod cli_tests {
     #[test]
     fn embedding_ffn_keeps_each_tokens_projection_independent() {
         let identity = q8_identity(32);
+        let weight = EmbeddingWeight {
+            bytes: &identity,
+            ggml_type: GGMLType::Q8_0,
+            n_cols: 32,
+            n_rows: 32,
+        };
         let mut normed = vec![0.0f32; 64];
         normed[0] = 1.0;
         normed[33] = 2.0;
@@ -170,18 +309,19 @@ mod cli_tests {
         hidden[0] = 10.0;
         hidden[33] = 20.0;
 
-        apply_embedding_ffn_q8_0(
+        apply_embedding_ffn_typed(
             &mut hidden,
             &normed,
             32,
             32,
-            &identity,
-            &identity,
-            &identity,
+            &weight,
+            &weight,
+            &weight,
             &mut [0.0; 32],
             &mut [0.0; 32],
             &mut [0.0; 32],
-        );
+        )
+        .unwrap();
 
         assert!((hidden[0] - 10.731059).abs() < 1e-4, "{}", hidden[0]);
         assert!((hidden[33] - 23.523041).abs() < 1e-4, "{}", hidden[33]);
@@ -580,6 +720,147 @@ struct LayerWeights<'a> {
     w_down: &'a [u8],
 }
 
+#[derive(Debug)]
+struct EmbeddingWeight<'a> {
+    bytes: &'a [u8],
+    ggml_type: GGMLType,
+    n_cols: usize,
+    n_rows: usize,
+}
+
+impl<'a> EmbeddingWeight<'a> {
+    fn load(
+        source: &'a dyn TensorSource,
+        name: &str,
+        n_cols: usize,
+        n_rows: usize,
+    ) -> Result<Self, String> {
+        let info = source
+            .tensor_info(name)
+            .ok_or_else(|| format!("Embedding tensor {name} not found"))?;
+        let expected_dims = [n_cols as u64, n_rows as u64];
+        if info.dims != expected_dims {
+            return Err(format!(
+                "Embedding tensor {name} has shape {:?}; expected {:?}",
+                info.dims, expected_dims
+            ));
+        }
+        if !matches!(info.ggml_type, GGMLType::F16 | GGMLType::Q8_0) {
+            return Err(format!(
+                "Embedding tensor {name} has unsupported type {:?}; expected F16 or Q8_0",
+                info.ggml_type
+            ));
+        }
+        if info.ggml_type == GGMLType::Q8_0 && n_cols % 32 != 0 {
+            return Err(format!(
+                "Embedding tensor {name} has Q8_0 columns {n_cols}; expected a multiple of 32"
+            ));
+        }
+        let n_elements = n_cols
+            .checked_mul(n_rows)
+            .ok_or_else(|| format!("Embedding tensor {name} shape overflows"))?;
+        let expected_bytes = info.ggml_type.nbytes(n_elements);
+        let bytes = source
+            .tensor_slice(name)
+            .ok_or_else(|| format!("Embedding tensor {name} data not found"))?;
+        if bytes.len() != expected_bytes {
+            return Err(format!(
+                "Embedding tensor {name} has {} bytes; expected {expected_bytes}",
+                bytes.len()
+            ));
+        }
+        Ok(Self {
+            bytes,
+            ggml_type: info.ggml_type,
+            n_cols,
+            n_rows,
+        })
+    }
+
+    fn get_row(&self, row: usize, output: &mut [f32]) -> Result<(), String> {
+        if row >= self.n_rows {
+            return Err(format!(
+                "Embedding row {row} is out of range for {} rows",
+                self.n_rows
+            ));
+        }
+        if output.len() != self.n_cols {
+            return Err(format!(
+                "Embedding row output has {} values; expected {}",
+                output.len(), self.n_cols
+            ));
+        }
+        match self.ggml_type {
+            GGMLType::F16 => {
+                let offset = row * self.n_cols * 2;
+                for (value, bytes) in output
+                    .iter_mut()
+                    .zip(self.bytes[offset..offset + self.n_cols * 2].chunks_exact(2))
+                {
+                    *value = f16_to_f32(u16::from_le_bytes(bytes.try_into().unwrap()));
+                }
+            }
+            GGMLType::Q8_0 => embedding_lookup_q8_0(self.bytes, row as u32, self.n_cols, output),
+            _ => unreachable!("EmbeddingWeight validates its type"),
+        }
+        Ok(())
+    }
+
+    fn matmul(&self, input: &[f32], output: &mut [f32]) -> Result<(), String> {
+        if input.len() != self.n_cols || output.len() != self.n_rows {
+            return Err(format!(
+                "Embedding matmul has input/output shape {}/{}; expected {}/{}",
+                input.len(),
+                output.len(),
+                self.n_cols,
+                self.n_rows
+            ));
+        }
+        match self.ggml_type {
+            GGMLType::F16 => {
+                let input_f16: Vec<u16> = input.iter().copied().map(f32_to_f16).collect();
+                for (row, value) in output.iter_mut().enumerate() {
+                    let offset = row * self.n_cols * 2;
+                    *value = dot_f16_f16_bytes(
+                        &input_f16,
+                        &self.bytes[offset..offset + self.n_cols * 2],
+                        self.n_cols,
+                    );
+                }
+            }
+            GGMLType::Q8_0 => {
+                let mut input_q8 = vec![0u8; self.n_cols];
+                let mut input_scales = vec![0.0f32; self.n_cols / 32];
+                quantize_q8_0_into(input, self.n_cols, &mut input_q8, &mut input_scales);
+                matmul_q8_0_quantized(
+                    self.bytes,
+                    &input_q8,
+                    &input_scales,
+                    output,
+                    self.n_cols,
+                    self.n_rows,
+                );
+            }
+            _ => unreachable!("EmbeddingWeight validates its type"),
+        }
+        Ok(())
+    }
+}
+
+struct EmbeddingLayerWeights<'a> {
+    attn_norm: Vec<f32>,
+    ffn_norm: Vec<f32>,
+    q_norm: Option<Vec<f32>>,
+    k_norm: Option<Vec<f32>>,
+    wq: EmbeddingWeight<'a>,
+    wk: EmbeddingWeight<'a>,
+    wv: EmbeddingWeight<'a>,
+    wo: EmbeddingWeight<'a>,
+    w_gate: EmbeddingWeight<'a>,
+    w_up: EmbeddingWeight<'a>,
+    w_down: EmbeddingWeight<'a>,
+}
+
 macro_rules! slice_from_mut {
     ($ptr:expr, $len:expr) => {
         unsafe { std::slice::from_raw_parts_mut($ptr, $len) }
@@ -666,69 +947,41 @@ fn attention_key_end(query: usize, n_tokens: usize, causal: bool) -> usize {
 }
 
 #[allow(clippy::too_many_arguments)]
-fn apply_embedding_ffn_q8_0(
+fn apply_embedding_ffn_typed(
     hidden: &mut [f32],
     normed: &[f32],
     n_embd: usize,
     n_ff: usize,
-    w_gate: &[u8],
-    w_up: &[u8],
-    w_down: &[u8],
+    w_gate: &EmbeddingWeight<'_>,
+    w_up: &EmbeddingWeight<'_>,
+    w_down: &EmbeddingWeight<'_>,
     gate_buf: &mut [f32],
     up_buf: &mut [f32],
     down_buf: &mut [f32],
-) {
+) -> Result<(), String> {
     assert_eq!(hidden.len(), normed.len());
     assert!(n_embd > 0 && n_ff > 0);
-    assert_eq!(n_embd % 32, 0);
-    assert_eq!(n_ff % 32, 0);
     assert_eq!(hidden.len() % n_embd, 0);
     assert_eq!(gate_buf.len(), n_ff);
     assert_eq!(up_buf.len(), n_ff);
     assert_eq!(down_buf.len(), n_embd);
 
-    let max_input = n_embd.max(n_ff);
-    let mut q8 = vec![0u8; max_input];
-    let mut scales = vec![0.0f32; max_input / 32];
-
     for (input, residual) in normed
         .chunks_exact(n_embd)
         .zip(hidden.chunks_exact_mut(n_embd))
     {
-        quantize_q8_0_into(input, n_embd, &mut q8[..n_embd], &mut scales[..n_embd / 32]);
-        matmul_q8_0_quantized(
-            w_gate,
-            &q8[..n_embd],
-            &scales[..n_embd / 32],
-            gate_buf,
-            n_embd,
-            n_ff,
-        );
-        matmul_q8_0_quantized(
-            w_up,
-            &q8[..n_embd],
-            &scales[..n_embd / 32],
-            up_buf,
-            n_embd,
-            n_ff,
-        );
+        w_gate.matmul(input, gate_buf)?;
+        w_up.matmul(input, up_buf)?;
 
         silu_mul_inplace(gate_buf, up_buf);
 
-        quantize_q8_0_into(up_buf, n_ff, &mut q8[..n_ff], &mut scales[..n_ff / 32]);
-        matmul_q8_0_quantized(
-            w_down,
-            &q8[..n_ff],
-            &scales[..n_ff / 32],
-            down_buf,
-            n_ff,
-            n_embd,
-        );
+        w_down.matmul(up_buf, down_buf)?;
 
         for index in 0..n_embd {
             residual[index] += down_buf[index];
         }
     }
+    Ok(())
 }
 
 fn pool_embedding_rows(
@@ -841,11 +1094,11 @@ fn run_embedding(
     let freq_base = config.rope_freq_base;
 
     let output_norm = get_f32_tensor(source, "output_norm.weight", n_embd);
-    let embd_weight = source.tensor_slice("token_embd.weight").expect("no embd");
-    let output_weight = source.tensor_slice("output.weight").unwrap_or(embd_weight);
+    let embd_weight = EmbeddingWeight::load(source, "token_embd.weight", n_embd, tokenizer.vocab_size())
+        .unwrap_or_else(|error| panic!("Failed to load embedding token weights: {error}"));
 
-    let layers: Vec<LayerWeights> = (0..n_layer)
-        .map(|l| LayerWeights {
+    let layers: Vec<EmbeddingLayerWeights> = (0..n_layer)
+        .map(|l| EmbeddingLayerWeights {
             attn_norm: get_f32_tensor(source, &format!("blk.{}.attn_norm.weight", l), n_embd),
             ffn_norm: get_f32_tensor(source, &format!("blk.{}.ffn_norm.weight", l), n_embd),
             q_norm: if is_qwen3 {
@@ -866,27 +1119,20 @@ fn run_embedding(
             } else {
                 None
             },
-            wq: source
-                .tensor_slice(&format!("blk.{}.attn_q.weight", l))
-                .unwrap(),
-            wk: source
-                .tensor_slice(&format!("blk.{}.attn_k.weight", l))
-                .unwrap(),
-            wv: source
-                .tensor_slice(&format!("blk.{}.attn_v.weight", l))
-                .unwrap(),
-            wo: source
-                .tensor_slice(&format!("blk.{}.attn_output.weight", l))
-                .unwrap(),
-            w_gate: source
-                .tensor_slice(&format!("blk.{}.ffn_gate.weight", l))
-                .unwrap(),
-            w_up: source
-                .tensor_slice(&format!("blk.{}.ffn_up.weight", l))
-                .unwrap(),
-            w_down: source
-                .tensor_slice(&format!("blk.{}.ffn_down.weight", l))
-                .unwrap(),
+            wq: EmbeddingWeight::load(source, &format!("blk.{l}.attn_q.weight"), n_embd, n_embd_q)
+                .unwrap_or_else(|error| panic!("Failed to load embedding Q weights: {error}")),
+            wk: EmbeddingWeight::load(source, &format!("blk.{l}.attn_k.weight"), n_embd, n_embd_gqa)
+                .unwrap_or_else(|error| panic!("Failed to load embedding K weights: {error}")),
+            wv: EmbeddingWeight::load(source, &format!("blk.{l}.attn_v.weight"), n_embd, n_embd_gqa)
+                .unwrap_or_else(|error| panic!("Failed to load embedding V weights: {error}")),
+            wo: EmbeddingWeight::load(source, &format!("blk.{l}.attn_output.weight"), n_embd_q, n_embd)
+                .unwrap_or_else(|error| panic!("Failed to load embedding output weights: {error}")),
+            w_gate: EmbeddingWeight::load(source, &format!("blk.{l}.ffn_gate.weight"), n_embd, n_ff)
+                .unwrap_or_else(|error| panic!("Failed to load embedding gate weights: {error}")),
+            w_up: EmbeddingWeight::load(source, &format!("blk.{l}.ffn_up.weight"), n_embd, n_ff)
+                .unwrap_or_else(|error| panic!("Failed to load embedding up weights: {error}")),
+            w_down: EmbeddingWeight::load(source, &format!("blk.{l}.ffn_down.weight"), n_ff, n_embd)
+                .unwrap_or_else(|error| panic!("Failed to load embedding down weights: {error}")),
         })
         .collect();
 
@@ -898,7 +1144,6 @@ fn run_embedding(
         );
     }
 
-    let vocab = tokenizer.vocab_size();
     let prompt_tokens = encode_embedding_input(&tokenizer, prompt);
     if prompt_tokens.is_empty() {
         eprintln!("Embedding input produced no tokens");
@@ -910,7 +1155,6 @@ fn run_embedding(
         .unwrap_or(4);
     let n_threads = resolve_thread_count(n_threads_arg, available_threads);
 
-    let max_n_in = n_embd_q.max(n_ff);
     let pool = std::sync::Arc::new(thread_pool::ComputePool::new(n_threads));
     eprintln!("compute pool: {} threads", pool.n_threads());
     if output == EmbeddingOutput::Summary {
@@ -927,8 +1171,6 @@ fn run_embedding(
     let mut attn_out = vec![0.0f32; n_tokens * n_embd_q];
     let mut attn_proj = vec![0.0f32; n_tokens * n_embd];
     let mut normed = vec![0.0f32; n_tokens * n_embd];
-    let mut q8_buf = vec![0u8; max_n_in];
-    let mut scale_buf = vec![0.0f32; max_n_in / 32];
     let mut gate_buf = vec![0.0f32; n_ff];
     let mut up_buf = vec![0.0f32; n_ff];
     let mut down_buf = vec![0.0f32; n_embd];
@@ -939,7 +1181,9 @@ fn run_embedding(
     for t in 0..n_tokens {
         let token_id = prompt_tokens[t];
         let x_slice = &mut hidden[t * n_embd..(t + 1) * n_embd];
-        embedding_lookup_q8_0(embd_weight, token_id, n_embd, x_slice);
+        embd_weight
+            .get_row(token_id as usize, x_slice)
+            .unwrap_or_else(|error| panic!("Failed to read embedding token row: {error}"));
     }
 
     eprintln!(
@@ -967,39 +1211,9 @@ fn run_embedding(
             let k = &mut k_buf[t * n_embd_gqa..(t + 1) * n_embd_gqa];
             let v = &mut v_buf[t * n_embd_gqa..(t + 1) * n_embd_gqa];
 
-            let mut local_q8 = vec![0u8; max_n_in];
-            let mut local_sc = vec![0.0f32; max_n_in / 32];
-            quantize_q8_0_into(
-                x,
-                n_embd,
-                &mut local_q8[..n_embd],
-                &mut local_sc[..n_embd / 32],
-            );
-
-            matmul_q8_0_quantized(
-                lw.wq,
-                &local_q8[..n_embd],
-                &local_sc[..n_embd / 32],
-                q,
-                n_embd,
-                n_embd_q,
-            );
-            matmul_q8_0_quantized(
-                lw.wk,
-                &local_q8[..n_embd],
-                &local_sc[..n_embd / 32],
-                k,
-                n_embd,
-                n_embd_gqa,
-            );
-            matmul_q8_0_quantized(
-                lw.wv,
-                &local_q8[..n_embd],
-                &local_sc[..n_embd / 32],
-                v,
-                n_embd,
-                n_embd_gqa,
-            );
+            lw.wq.matmul(x, q).unwrap_or_else(|error| panic!("Embedding Q matmul failed: {error}"));
+            lw.wk.matmul(x, k).unwrap_or_else(|error| panic!("Embedding K matmul failed: {error}"));
+            lw.wv.matmul(x, v).unwrap_or_else(|error| panic!("Embedding V matmul failed: {error}"));
         }
 
         if let (Some(qn), Some(kn)) = (&lw.q_norm, &lw.k_norm) {
@@ -1079,11 +1293,7 @@ fn run_embedding(
             let attn = &attn_out[t * n_embd_q..(t + 1) * n_embd_q];
             let proj = &mut attn_proj[t * n_embd..(t + 1) * n_embd];
 
-            let mut local_q8 = vec![0u8; n_embd_q];
-            let mut local_sc = vec![0.0f32; n_embd_q / 32];
-            quantize_q8_0_into(attn, n_embd_q, &mut local_q8, &mut local_sc);
-
-            matmul_q8_0_quantized(lw.wo, &local_q8, &local_sc, proj, n_embd_q, n_embd);
+            lw.wo.matmul(attn, proj).unwrap_or_else(|error| panic!("Embedding output matmul failed: {error}"));
         }
 
         for t in 0..n_tokens {
@@ -1103,18 +1313,19 @@ fn run_embedding(
             );
         }
 
-        apply_embedding_ffn_q8_0(
+        apply_embedding_ffn_typed(
             &mut hidden,
             &normed,
             n_embd,
             n_ff,
-            lw.w_gate,
-            lw.w_up,
-            lw.w_down,
+            &lw.w_gate,
+            &lw.w_up,
+            &lw.w_down,
             &mut gate_buf,
             &mut up_buf,
             &mut down_buf,
-        );
+        )
+        .unwrap_or_else(|error| panic!("Embedding FFN failed: {error}"));
     }
 
     for t in 0..n_tokens {

--- a/RustModelInference/src/main.rs
+++ b/RustModelInference/src/main.rs
@@ -1,9 +1,10 @@
 use std::io::{self, Write};
+use std::path::Path;
 use std::time::{Duration, Instant};
 
-use rust_model_inference::*;
 #[cfg(feature = "parity-trace")]
 use rust_model_inference::parity_trace;
+use rust_model_inference::*;
 
 #[derive(Clone, Copy, PartialEq)]
 enum KvFormat {
@@ -347,9 +348,9 @@ mod cli_tests {
     #[ignore = "requires QWEN3_EMBEDDING_MODEL"]
     fn qwen3_embedding_tokens_match_pinned_llama_cpp() {
         let model = std::env::var("QWEN3_EMBEDDING_MODEL").unwrap();
-        let loader = GGUFLoader::from_file(&model).unwrap();
+        let source = open_model_source(Path::new(&model), ComponentRole::Llm).unwrap();
         let tokenizer =
-            BPETokenizer::from_gguf_metadata(|key| loader.metadata(key).cloned()).unwrap();
+            BPETokenizer::from_gguf_metadata(|key| source.metadata(key).cloned()).unwrap();
 
         for &(text, expected) in EMBEDDING_TOKEN_CASES {
             assert_eq!(
@@ -469,46 +470,62 @@ fn main() {
         i += 1;
     }
 
-    let result: Result<(), String> = (|| -> Result<(), String> {
-        if !model_path.is_empty() && (!mmproj_path.is_empty() || !image_path.is_empty()) {
-            return run_multimodal(
-                &model_path,
-                &mmproj_path,
-                &image_path,
+    if model_path.is_empty() {
+        run_self_test();
+        return;
+    }
+
+    let model_path = Path::new(&model_path);
+    let source = open_or_exit(model_path, ComponentRole::Llm);
+    let arch = source
+        .metadata("general.architecture")
+        .and_then(MetaValue::to_string_val)
+        .unwrap_or_default();
+    let explicit_mmproj = (!mmproj_path.is_empty()).then(|| Path::new(mmproj_path.as_str()));
+    let image = (!image_path.is_empty()).then(|| Path::new(image_path.as_str()));
+
+    if explicit_mmproj.is_some() || image.is_some() {
+        run_or_exit(run_multimodal(
+            source.as_ref(),
+            model_path,
+            explicit_mmproj,
+            image,
+            &prompt,
+            max_tokens,
+            temperature,
+            n_threads,
+        ));
+    } else if !prompt.is_empty() {
+        if arch == "qwen35" {
+            run_or_exit(run_multimodal(
+                source.as_ref(),
+                model_path,
+                None,
+                None,
                 &prompt,
                 max_tokens,
                 temperature,
                 n_threads,
+            ));
+        } else if embedding_mode {
+            run_embedding(
+                source.as_ref(),
+                &prompt,
+                n_threads,
+                kv_format,
+                embedding_output,
             );
-        }
-
-        if !model_path.is_empty() && !prompt.is_empty() {
-            let loader = GGUFLoader::from_file(&model_path)
-                .map_err(|error| format!("Failed to load model {model_path}: {error}"))?;
-            let arch = loader
-                .metadata("general.architecture")
-                .and_then(MetaValue::to_string_val)
-                .unwrap_or_default();
-            if arch == "qwen35" {
-                return run_multimodal(
-                    &model_path,
-                    "",
-                    "",
-                    &prompt,
-                    max_tokens,
-                    temperature,
-                    n_threads,
-                );
-            }
-            if embedding_mode {
-                run_embedding(&model_path, &prompt, n_threads, kv_format, embedding_output);
-                return Ok(());
-            }
-            if dump_logits {
-                return run_dump_logits(&model_path, &prompt, max_tokens, n_threads, kv_format);
-            }
-            return run_inference(
-                &model_path,
+        } else if dump_logits {
+            run_or_exit(run_dump_logits(
+                source.as_ref(),
+                &prompt,
+                max_tokens,
+                n_threads,
+                kv_format,
+            ));
+        } else {
+            run_or_exit(run_inference(
+                source.as_ref(),
                 &prompt,
                 max_tokens,
                 temperature,
@@ -516,17 +533,30 @@ fn main() {
                 bench,
                 profile,
                 kv_format,
-            );
+            ));
         }
+    } else {
+        run_or_exit(run_interactive(
+            source.as_ref(),
+            max_tokens,
+            temperature,
+            n_threads,
+        ));
+    }
+}
 
-        if !model_path.is_empty() {
-            return run_interactive(&model_path, max_tokens, temperature, n_threads);
-        }
-
-        run_self_test();
-        Ok(())
-    })();
-    run_or_exit(result);
+fn open_or_exit(path: &Path, role: ComponentRole) -> Box<dyn TensorSource> {
+    open_model_source(path, role).unwrap_or_else(|error| {
+        eprintln!(
+            "Failed to load {} component from {}: {error}",
+            match role {
+                ComponentRole::Llm => "LLM",
+                ComponentRole::Mmproj => "mmproj",
+            },
+            path.display(),
+        );
+        std::process::exit(1);
+    })
 }
 
 fn run_or_exit(result: Result<(), String>) {
@@ -764,28 +794,24 @@ fn l2_normalize_embedding(values: &mut [f32]) -> Result<(), String> {
 }
 
 fn run_embedding(
-    model_path: &str,
+    source: &dyn TensorSource,
     prompt: &str,
     n_threads_arg: usize,
     _kv_format: KvFormat,
     output: EmbeddingOutput,
 ) {
     let t0 = Instant::now();
-    if output == EmbeddingOutput::Summary {
-        println!("Loading {} ...", model_path);
-    }
-    let loader = GGUFLoader::from_file(model_path).expect("Failed to load GGUF");
-    let config = loader.model_config().expect("Failed to parse model config");
+    let config = model_config_from_source(source).expect("Failed to parse model config");
 
-    let arch = loader
+    let arch = source
         .metadata("general.architecture")
         .and_then(|v| v.to_string_val())
         .unwrap_or_default();
     let is_qwen3 = arch == "qwen3";
 
-    let tokenizer = BPETokenizer::from_gguf_metadata(|k| loader.metadata(k).cloned())
+    let tokenizer = BPETokenizer::from_gguf_metadata(|k| source.metadata(k).cloned())
         .expect("Failed to init tokenizer");
-    let embedding_cfg = embedding_config(&arch, |key| loader.metadata(key).cloned())
+    let embedding_cfg = embedding_config(&arch, |key| source.metadata(key).cloned())
         .unwrap_or_else(|error| {
             eprintln!("Embedding metadata error: {error}");
             std::process::exit(1);
@@ -796,14 +822,14 @@ fn run_embedding(
     let n_head = config.n_head;
     let n_head_kv = config.n_head_kv;
     let n_embd_head = config.n_embd_head;
-    let n_embd_head_k = if let Some(v) = loader.metadata(&format!("{}.attention.key_length", arch))
+    let n_embd_head_k = if let Some(v) = source.metadata(&format!("{}.attention.key_length", arch))
     {
         v.to_u64().unwrap_or(n_embd_head as u64) as usize
     } else {
         n_embd_head
     };
     let n_embd_head_v =
-        if let Some(v) = loader.metadata(&format!("{}.attention.value_length", arch)) {
+        if let Some(v) = source.metadata(&format!("{}.attention.value_length", arch)) {
             v.to_u64().unwrap_or(n_embd_head as u64) as usize
         } else {
             n_embd_head
@@ -814,17 +840,17 @@ fn run_embedding(
     let eps = config.norm_eps;
     let freq_base = config.rope_freq_base;
 
-    let output_norm = get_f32_tensor(&loader, "output_norm.weight", n_embd);
-    let embd_weight = loader.tensor_slice("token_embd.weight").expect("no embd");
-    let output_weight = loader.tensor_slice("output.weight").unwrap_or(embd_weight);
+    let output_norm = get_f32_tensor(source, "output_norm.weight", n_embd);
+    let embd_weight = source.tensor_slice("token_embd.weight").expect("no embd");
+    let output_weight = source.tensor_slice("output.weight").unwrap_or(embd_weight);
 
     let layers: Vec<LayerWeights> = (0..n_layer)
         .map(|l| LayerWeights {
-            attn_norm: get_f32_tensor(&loader, &format!("blk.{}.attn_norm.weight", l), n_embd),
-            ffn_norm: get_f32_tensor(&loader, &format!("blk.{}.ffn_norm.weight", l), n_embd),
+            attn_norm: get_f32_tensor(source, &format!("blk.{}.attn_norm.weight", l), n_embd),
+            ffn_norm: get_f32_tensor(source, &format!("blk.{}.ffn_norm.weight", l), n_embd),
             q_norm: if is_qwen3 {
                 Some(get_f32_tensor(
-                    &loader,
+                    source,
                     &format!("blk.{}.attn_q_norm.weight", l),
                     n_embd_head_k,
                 ))
@@ -833,32 +859,32 @@ fn run_embedding(
             },
             k_norm: if is_qwen3 {
                 Some(get_f32_tensor(
-                    &loader,
+                    source,
                     &format!("blk.{}.attn_k_norm.weight", l),
                     n_embd_head_k,
                 ))
             } else {
                 None
             },
-            wq: loader
+            wq: source
                 .tensor_slice(&format!("blk.{}.attn_q.weight", l))
                 .unwrap(),
-            wk: loader
+            wk: source
                 .tensor_slice(&format!("blk.{}.attn_k.weight", l))
                 .unwrap(),
-            wv: loader
+            wv: source
                 .tensor_slice(&format!("blk.{}.attn_v.weight", l))
                 .unwrap(),
-            wo: loader
+            wo: source
                 .tensor_slice(&format!("blk.{}.attn_output.weight", l))
                 .unwrap(),
-            w_gate: loader
+            w_gate: source
                 .tensor_slice(&format!("blk.{}.ffn_gate.weight", l))
                 .unwrap(),
-            w_up: loader
+            w_up: source
                 .tensor_slice(&format!("blk.{}.ffn_up.weight", l))
                 .unwrap(),
-            w_down: loader
+            w_down: source
                 .tensor_slice(&format!("blk.{}.ffn_down.weight", l))
                 .unwrap(),
         })
@@ -1141,28 +1167,25 @@ fn run_embedding(
 }
 
 fn run_dump_logits(
-    model_path: &str,
+    source: &dyn TensorSource,
     prompt: &str,
     max_tokens: usize,
     n_threads_arg: usize,
     kv_format: KvFormat,
 ) -> Result<(), String> {
-    let loader = GGUFLoader::from_file(model_path)
-        .map_err(|error| format!("Failed to load model {model_path}: {error}"))?;
-    let config = loader
-        .model_config()
+    let config = model_config_from_source(source)
         .map_err(|error| format!("Failed to parse model config: {error}"))?;
 
     let mut bin_out = std::fs::File::create("/tmp/rust_logits.bin")
         .map_err(|error| format!("Failed to create /tmp/rust_logits.bin: {error}"))?;
 
-    let arch = loader
+    let arch = source
         .metadata("general.architecture")
         .and_then(|v| v.to_string_val())
         .unwrap_or_default();
     let is_qwen3 = arch == "qwen3";
 
-    let tokenizer = BPETokenizer::from_gguf_metadata(|k| loader.metadata(k).cloned())
+    let tokenizer = BPETokenizer::from_gguf_metadata(|k| source.metadata(k).cloned())
         .map_err(|error| format!("Failed to initialize tokenizer: {error}"))?;
 
     let max_ctx = 512usize.min(config.n_ctx);
@@ -1171,14 +1194,14 @@ fn run_dump_logits(
     let n_head = config.n_head;
     let n_head_kv = config.n_head_kv;
     let n_embd_head = config.n_embd_head;
-    let n_embd_head_k = if let Some(v) = loader.metadata(&format!("{}.attention.key_length", arch))
+    let n_embd_head_k = if let Some(v) = source.metadata(&format!("{}.attention.key_length", arch))
     {
         v.to_u64().unwrap_or(n_embd_head as u64) as usize
     } else {
         n_embd_head
     };
     let n_embd_head_v =
-        if let Some(v) = loader.metadata(&format!("{}.attention.value_length", arch)) {
+        if let Some(v) = source.metadata(&format!("{}.attention.value_length", arch)) {
             v.to_u64().unwrap_or(n_embd_head as u64) as usize
         } else {
             n_embd_head
@@ -1189,17 +1212,17 @@ fn run_dump_logits(
     let eps = config.norm_eps;
     let freq_base = config.rope_freq_base;
 
-    let output_norm = get_f32_tensor(&loader, "output_norm.weight", n_embd);
-    let embd_weight = loader.tensor_slice("token_embd.weight").expect("no embd");
-    let output_weight = loader.tensor_slice("output.weight").unwrap_or(embd_weight);
+    let output_norm = get_f32_tensor(source, "output_norm.weight", n_embd);
+    let embd_weight = source.tensor_slice("token_embd.weight").expect("no embd");
+    let output_weight = source.tensor_slice("output.weight").unwrap_or(embd_weight);
 
     let layers: Vec<LayerWeights> = (0..n_layer)
         .map(|l| LayerWeights {
-            attn_norm: get_f32_tensor(&loader, &format!("blk.{}.attn_norm.weight", l), n_embd),
-            ffn_norm: get_f32_tensor(&loader, &format!("blk.{}.ffn_norm.weight", l), n_embd),
+            attn_norm: get_f32_tensor(source, &format!("blk.{}.attn_norm.weight", l), n_embd),
+            ffn_norm: get_f32_tensor(source, &format!("blk.{}.ffn_norm.weight", l), n_embd),
             q_norm: if is_qwen3 {
                 Some(get_f32_tensor(
-                    &loader,
+                    source,
                     &format!("blk.{}.attn_q_norm.weight", l),
                     n_embd_head_k,
                 ))
@@ -1208,32 +1231,32 @@ fn run_dump_logits(
             },
             k_norm: if is_qwen3 {
                 Some(get_f32_tensor(
-                    &loader,
+                    source,
                     &format!("blk.{}.attn_k_norm.weight", l),
                     n_embd_head_k,
                 ))
             } else {
                 None
             },
-            wq: loader
+            wq: source
                 .tensor_slice(&format!("blk.{}.attn_q.weight", l))
                 .unwrap(),
-            wk: loader
+            wk: source
                 .tensor_slice(&format!("blk.{}.attn_k.weight", l))
                 .unwrap(),
-            wv: loader
+            wv: source
                 .tensor_slice(&format!("blk.{}.attn_v.weight", l))
                 .unwrap(),
-            wo: loader
+            wo: source
                 .tensor_slice(&format!("blk.{}.attn_output.weight", l))
                 .unwrap(),
-            w_gate: loader
+            w_gate: source
                 .tensor_slice(&format!("blk.{}.ffn_gate.weight", l))
                 .unwrap(),
-            w_up: loader
+            w_up: source
                 .tensor_slice(&format!("blk.{}.ffn_up.weight", l))
                 .unwrap(),
-            w_down: loader
+            w_down: source
                 .tensor_slice(&format!("blk.{}.ffn_down.weight", l))
                 .unwrap(),
         })
@@ -1771,7 +1794,7 @@ fn run_dump_logits(
 }
 
 fn run_inference(
-    model_path: &str,
+    source: &dyn TensorSource,
     prompt: &str,
     max_tokens: usize,
     temperature: f32,
@@ -1781,20 +1804,16 @@ fn run_inference(
     kv_format: KvFormat,
 ) -> Result<(), String> {
     let t0 = Instant::now();
-    println!("Loading {} ...", model_path);
-    let loader = GGUFLoader::from_file(model_path)
-        .map_err(|error| format!("Failed to load model {model_path}: {error}"))?;
-    let config = loader
-        .model_config()
+    let config = model_config_from_source(source)
         .map_err(|error| format!("Failed to parse model config: {error}"))?;
 
-    let arch = loader
+    let arch = source
         .metadata("general.architecture")
         .and_then(|v| v.to_string_val())
         .unwrap_or_default();
     let is_qwen3 = arch == "qwen3";
 
-    let tokenizer = BPETokenizer::from_gguf_metadata(|k| loader.metadata(k).cloned())
+    let tokenizer = BPETokenizer::from_gguf_metadata(|k| source.metadata(k).cloned())
         .map_err(|error| format!("Failed to initialize tokenizer: {error}"))?;
 
     let max_ctx = 512usize.min(config.n_ctx);
@@ -1803,14 +1822,14 @@ fn run_inference(
     let n_head = config.n_head;
     let n_head_kv = config.n_head_kv;
     let n_embd_head = config.n_embd_head;
-    let n_embd_head_k = if let Some(v) = loader.metadata(&format!("{}.attention.key_length", arch))
+    let n_embd_head_k = if let Some(v) = source.metadata(&format!("{}.attention.key_length", arch))
     {
         v.to_u64().unwrap_or(n_embd_head as u64) as usize
     } else {
         n_embd_head
     };
     let n_embd_head_v =
-        if let Some(v) = loader.metadata(&format!("{}.attention.value_length", arch)) {
+        if let Some(v) = source.metadata(&format!("{}.attention.value_length", arch)) {
             v.to_u64().unwrap_or(n_embd_head as u64) as usize
         } else {
             n_embd_head
@@ -1821,17 +1840,17 @@ fn run_inference(
     let eps = config.norm_eps;
     let freq_base = config.rope_freq_base;
 
-    let output_norm = get_f32_tensor(&loader, "output_norm.weight", n_embd);
-    let embd_weight = loader.tensor_slice("token_embd.weight").expect("no embd");
-    let output_weight = loader.tensor_slice("output.weight").unwrap_or(embd_weight);
+    let output_norm = get_f32_tensor(source, "output_norm.weight", n_embd);
+    let embd_weight = source.tensor_slice("token_embd.weight").expect("no embd");
+    let output_weight = source.tensor_slice("output.weight").unwrap_or(embd_weight);
 
     let layers: Vec<LayerWeights> = (0..n_layer)
         .map(|l| LayerWeights {
-            attn_norm: get_f32_tensor(&loader, &format!("blk.{}.attn_norm.weight", l), n_embd),
-            ffn_norm: get_f32_tensor(&loader, &format!("blk.{}.ffn_norm.weight", l), n_embd),
+            attn_norm: get_f32_tensor(source, &format!("blk.{}.attn_norm.weight", l), n_embd),
+            ffn_norm: get_f32_tensor(source, &format!("blk.{}.ffn_norm.weight", l), n_embd),
             q_norm: if is_qwen3 {
                 Some(get_f32_tensor(
-                    &loader,
+                    source,
                     &format!("blk.{}.attn_q_norm.weight", l),
                     n_embd_head_k,
                 ))
@@ -1840,32 +1859,32 @@ fn run_inference(
             },
             k_norm: if is_qwen3 {
                 Some(get_f32_tensor(
-                    &loader,
+                    source,
                     &format!("blk.{}.attn_k_norm.weight", l),
                     n_embd_head_k,
                 ))
             } else {
                 None
             },
-            wq: loader
+            wq: source
                 .tensor_slice(&format!("blk.{}.attn_q.weight", l))
                 .unwrap(),
-            wk: loader
+            wk: source
                 .tensor_slice(&format!("blk.{}.attn_k.weight", l))
                 .unwrap(),
-            wv: loader
+            wv: source
                 .tensor_slice(&format!("blk.{}.attn_v.weight", l))
                 .unwrap(),
-            wo: loader
+            wo: source
                 .tensor_slice(&format!("blk.{}.attn_output.weight", l))
                 .unwrap(),
-            w_gate: loader
+            w_gate: source
                 .tensor_slice(&format!("blk.{}.ffn_gate.weight", l))
                 .unwrap(),
-            w_up: loader
+            w_up: source
                 .tensor_slice(&format!("blk.{}.ffn_up.weight", l))
                 .unwrap(),
-            w_down: loader
+            w_down: source
                 .tensor_slice(&format!("blk.{}.ffn_down.weight", l))
                 .unwrap(),
         })
@@ -2518,37 +2537,33 @@ fn run_inference(
     Ok(())
 }
 
-fn get_f32_tensor(loader: &GGUFLoader, name: &str, expected_len: usize) -> Vec<f32> {
-    let ti = loader
+fn get_f32_tensor<S: TensorSource + ?Sized>(
+    source: &S,
+    name: &str,
+    expected_len: usize,
+) -> Vec<f32> {
+    let info = source
         .tensor_info(name)
-        .expect(&format!("tensor {} not found", name));
-    let slice = loader
+        .unwrap_or_else(|| panic!("tensor {name} not found"));
+    let bytes = source
         .tensor_slice(name)
-        .expect(&format!("slice {} not found", name));
-    let mut out = vec![0.0f32; expected_len];
-    if ti.ggml_type == GGMLType::F32 {
-        let n = expected_len.min(slice.len() / 4);
-        for i in 0..n {
-            let bytes = [
-                slice[i * 4],
-                slice[i * 4 + 1],
-                slice[i * 4 + 2],
-                slice[i * 4 + 3],
-            ];
-            out[i] = f32::from_le_bytes(bytes);
+        .unwrap_or_else(|| panic!("slice {name} not found"));
+    let mut output = vec![0.0; expected_len];
+    if info.ggml_type == GGMLType::F32 {
+        for (value, chunk) in output.iter_mut().zip(bytes.chunks_exact(4)) {
+            *value = f32::from_le_bytes(chunk.try_into().unwrap());
         }
     }
-    out
+    output
 }
 
 fn run_interactive(
-    model_path: &str,
+    source: &dyn TensorSource,
     max_tokens: usize,
     temperature: f32,
     n_threads_arg: usize,
 ) -> Result<(), String> {
     println!("=== RustModelInference Interactive Mode ===");
-    println!("Model: {}", model_path);
     println!("Type your prompt and press Enter. Ctrl+C to exit.\n");
 
     loop {
@@ -2569,7 +2584,7 @@ fn run_interactive(
             continue;
         }
         run_inference(
-            model_path,
+            source,
             line,
             max_tokens,
             temperature,
@@ -2685,11 +2700,11 @@ fn sample_token(logits: &[f32], temperature: f32) -> i32 {
     (logits.len() - 1) as i32
 }
 
-fn decode_image(path: &str) -> Result<image::DynamicImage, String> {
+fn decode_image(path: &Path) -> Result<image::DynamicImage, String> {
     let bytes = std::fs::read(path)
-        .map_err(|error| format!("Failed to read image {path}: {error}"))?;
+        .map_err(|error| format!("Failed to read image {}: {error}", path.display()))?;
     image::load_from_memory(&bytes)
-        .map_err(|error| format!("Failed to decode image {path}: {error}"))
+        .map_err(|error| format!("Failed to decode image {}: {error}", path.display()))
 }
 
 fn normalize_resized_image(
@@ -2726,25 +2741,16 @@ fn normalize_resized_image(
 }
 
 fn run_multimodal(
-    model_path: &str,
-    mmproj_path: &str,
-    image_path: &str,
+    llm_source: &dyn TensorSource,
+    model_path: &Path,
+    mmproj_path: Option<&Path>,
+    image_path: Option<&Path>,
     prompt: &str,
     max_tokens: usize,
     temperature: f32,
     n_threads_arg: usize,
 ) -> Result<(), String> {
-    let has_image = !image_path.is_empty();
-    let has_mmproj = !mmproj_path.is_empty();
-    if has_image != has_mmproj {
-        return Err("Multimodal inference requires both --image and --mmproj".into());
-    }
-
-    println!("Loading model {} ...", model_path);
-    let llm_loader = GGUFLoader::from_file(model_path)
-        .map_err(|error| format!("Failed to load model {model_path}: {error}"))?;
-
-    let arch = llm_loader
+    let arch = llm_source
         .metadata("general.architecture")
         .and_then(|v| v.to_string_val())
         .unwrap_or_default();
@@ -2757,11 +2763,24 @@ fn run_multimodal(
 
     #[cfg(feature = "parity-trace")]
     let mut vision_original_size = None;
-    let (image_grid, vis_embeddings_vec) = if has_image {
-        println!("Loading mmproj {} ...", mmproj_path);
-        let mmproj_loader = GGUFLoader::from_file(mmproj_path)
-            .map_err(|error| format!("Failed to load mmproj {mmproj_path}: {error}"))?;
-        let mut encoder = VisionEncoder::from_gguf(&mmproj_loader)
+    let (image_grid, vis_embeddings_vec) = if let Some(image_path) = image_path {
+        let projector_path = mmproj_path.unwrap_or(model_path);
+        println!("Loading mmproj {} ...", projector_path.display());
+        let mmproj_source =
+            open_model_source(projector_path, ComponentRole::Mmproj).map_err(|error| {
+                if mmproj_path.is_none() {
+                    format!(
+                        "Model {} has no bundled mmproj; pass --mmproj: {error}",
+                        model_path.display()
+                    )
+                } else {
+                    format!(
+                        "Failed to load mmproj {}: {error}",
+                        projector_path.display()
+                    )
+                }
+            })?;
+        let mut encoder = VisionEncoder::from_source(mmproj_source.as_ref())
             .map_err(|error| format!("Failed to parse vision encoder: {error}"))?;
         encoder.precompute();
         println!(
@@ -2819,26 +2838,30 @@ fn run_multimodal(
                 scratch.projected.len()
             ));
         }
-        println!("Vision tokens: {} (dim={})", grid.token_count(), projection_dim);
+        println!(
+            "Vision tokens: {} (dim={})",
+            grid.token_count(),
+            projection_dim
+        );
         (Some(grid), scratch.projected[..projected_len].to_vec())
     } else {
         (None, Vec::new())
     };
     let n_vis_tokens = image_grid.map(VisionGrid::token_count).unwrap_or(0);
     let vis_embeddings = &vis_embeddings_vec[..];
-    if has_image {
+    if image_grid.is_some() {
         println!(
             "First 5 vision embedding values: {:?}",
             &vis_embeddings[..5.min(vis_embeddings.len())]
         );
     }
 
-    let llm = Qwen35Model::from_gguf(&llm_loader)
+    let llm = Qwen35Model::from_source(llm_source)
         .map_err(|error| format!("Failed to parse Qwen3.5 model: {error}"))?;
     println!("Qwen3.5 model loaded: {} layers, n_embd={}, n_head={}, n_ff={}, rope_freq_base={}, rope_sections={:?}, rope_dim_count={}", llm.config.n_layer, llm.config.n_embd, llm.config.n_head, llm.config.n_ff, llm.config.rope_freq_base, llm.config.rope_dimension_sections, llm.config.rope_dimension_count);
     // llm.precompute_f32();
 
-    let tokenizer = BPETokenizer::from_gguf_metadata(|k| llm_loader.metadata(k).cloned())
+    let tokenizer = BPETokenizer::from_gguf_metadata(|k| llm_source.metadata(k).cloned())
         .map_err(|error| format!("Failed to initialize tokenizer: {error}"))?;
     let image_token_id = if image_grid.is_some() {
         Some(

--- a/RustModelInference/src/model.rs
+++ b/RustModelInference/src/model.rs
@@ -64,8 +64,8 @@ impl GGMLType {
             Self::Q5_1 => (32, 24),
             Self::Q8_0 => (32, 34),
             Self::Q8_1 => (32, 36),
-            Self::Q2K => (256, 256),
-            Self::Q3K => (256, 256),
+            Self::Q2K => (256, 84),
+            Self::Q3K => (256, 110),
             Self::Q4K => (256, 144),
             Self::Q5K => (256, 176),
             Self::Q6K => (256, 210),
@@ -122,7 +122,7 @@ impl MetaValueType {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum MetaValue {
     Uint8(u8),
     Int8(i8),
@@ -183,7 +183,7 @@ impl MetaValue {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TensorInfo {
     pub name: String,
     pub dims: Vec<u64>,
@@ -192,23 +192,65 @@ pub struct TensorInfo {
 }
 
 impl TensorInfo {
+    pub fn checked_n_elements(&self) -> Option<u64> {
+        let (first, rest) = self.dims.split_first()?;
+        rest.iter()
+            .try_fold(*first, |count, dimension| count.checked_mul(*dimension))
+    }
+
+    pub fn checked_nbytes(&self) -> Option<u64> {
+        let row_elements = *self.dims.first()?;
+        let rows = self.dims[1..]
+            .iter()
+            .try_fold(1u64, |count, dimension| count.checked_mul(*dimension))?;
+        let (block_elements, block_bytes) = self.ggml_type.type_traits();
+        let block_elements = block_elements as u64;
+        if row_elements % block_elements != 0 {
+            return None;
+        }
+        row_elements
+            .checked_div(block_elements)?
+            .checked_mul(block_bytes as u64)?
+            .checked_mul(rows)
+    }
+
     pub fn n_elements(&self) -> usize {
-        self.dims.iter().product::<u64>() as usize
+        usize::try_from(self.checked_n_elements().expect("validated tensor shape"))
+            .expect("validated tensor element count fits usize")
     }
 
     pub fn nbytes(&self) -> usize {
-        self.ggml_type.nbytes(self.n_elements())
+        usize::try_from(self.checked_nbytes().expect("validated tensor byte size"))
+            .expect("validated tensor byte size fits usize")
     }
 }
 
-struct ByteReader<'a> {
+pub(crate) struct ByteReader<'a> {
     data: &'a [u8],
     pos: usize,
 }
 
 impl<'a> ByteReader<'a> {
-    fn new(data: &'a [u8]) -> Self {
+    pub(crate) fn new(data: &'a [u8]) -> Self {
         Self { data, pos: 0 }
+    }
+
+    fn read_len(&mut self, context: &str) -> Result<usize, String> {
+        usize::try_from(self.read_u64()?)
+            .map_err(|_| format!("{context} length does not fit usize"))
+    }
+
+    pub(crate) fn read_exact(&mut self, len: usize, context: &str) -> Result<&'a [u8], String> {
+        let end = self
+            .pos
+            .checked_add(len)
+            .ok_or_else(|| format!("{context} range overflow"))?;
+        let value = self
+            .data
+            .get(self.pos..end)
+            .ok_or_else(|| format!("EOF reading {context} of length {len}"))?;
+        self.pos = end;
+        Ok(value)
     }
 
     fn remaining(&self) -> usize {
@@ -241,7 +283,7 @@ impl<'a> ByteReader<'a> {
         Ok(self.read_u16()? as i16)
     }
 
-    fn read_u32(&mut self) -> Result<u32, String> {
+    pub(crate) fn read_u32(&mut self) -> Result<u32, String> {
         if self.remaining() < 4 {
             return Err("EOF reading u32".into());
         }
@@ -255,11 +297,11 @@ impl<'a> ByteReader<'a> {
         Ok(v)
     }
 
-    fn read_i32(&mut self) -> Result<i32, String> {
+    pub(crate) fn read_i32(&mut self) -> Result<i32, String> {
         Ok(self.read_u32()? as i32)
     }
 
-    fn read_u64(&mut self) -> Result<u64, String> {
+    pub(crate) fn read_u64(&mut self) -> Result<u64, String> {
         if self.remaining() < 8 {
             return Err("EOF reading u64".into());
         }
@@ -281,17 +323,13 @@ impl<'a> ByteReader<'a> {
         Ok(f64::from_bits(self.read_u64()?))
     }
 
-    fn read_string(&mut self) -> Result<String, String> {
-        let len = self.read_u64()? as usize;
-        if self.remaining() < len {
-            return Err(format!("EOF reading string of len {}", len));
-        }
-        let s = String::from_utf8_lossy(&self.data[self.pos..self.pos + len]).into_owned();
-        self.pos += len;
-        Ok(s)
+    pub(crate) fn read_string(&mut self) -> Result<String, String> {
+        let len = self.read_len("string")?;
+        let bytes = self.read_exact(len, "string")?;
+        String::from_utf8(bytes.to_vec()).map_err(|error| format!("Invalid UTF-8 string: {error}"))
     }
 
-    fn read_meta_value(&mut self, vtype: MetaValueType) -> Result<MetaValue, String> {
+    pub(crate) fn read_meta_value(&mut self, vtype: MetaValueType) -> Result<MetaValue, String> {
         match vtype {
             MetaValueType::Uint8 => Ok(MetaValue::Uint8(self.read_u8()?)),
             MetaValueType::Int8 => Ok(MetaValue::Int8(self.read_i8()?)),
@@ -300,7 +338,11 @@ impl<'a> ByteReader<'a> {
             MetaValueType::Uint32 => Ok(MetaValue::Uint32(self.read_u32()?)),
             MetaValueType::Int32 => Ok(MetaValue::Int32(self.read_i32()?)),
             MetaValueType::Float32 => Ok(MetaValue::Float32(self.read_f32()?)),
-            MetaValueType::Bool => Ok(MetaValue::Bool(self.read_u8()? != 0)),
+            MetaValueType::Bool => match self.read_u8()? {
+                0 => Ok(MetaValue::Bool(false)),
+                1 => Ok(MetaValue::Bool(true)),
+                value => Err(format!("Invalid bool value: {value}")),
+            },
             MetaValueType::String => Ok(MetaValue::String(self.read_string()?)),
             MetaValueType::Uint64 => Ok(MetaValue::Uint64(self.read_u64()?)),
             MetaValueType::Int64 => Ok(MetaValue::Int64(self.read_i64()?)),
@@ -309,7 +351,7 @@ impl<'a> ByteReader<'a> {
                 let elem_type_i32 = self.read_i32()?;
                 let elem_type = MetaValueType::from_i32(elem_type_i32)
                     .ok_or_else(|| format!("Unknown meta value type: {}", elem_type_i32))?;
-                let n = self.read_u64()? as usize;
+                let n = self.read_len("array")?;
                 let mut vals = Vec::with_capacity(n);
                 for _ in 0..n {
                     vals.push(self.read_meta_value(elem_type)?);
@@ -319,7 +361,7 @@ impl<'a> ByteReader<'a> {
         }
     }
 
-    fn pos(&self) -> usize {
+    pub(crate) fn pos(&self) -> usize {
         self.pos
     }
 }
@@ -346,7 +388,7 @@ impl std::fmt::Debug for GGUFLoader {
 }
 
 impl GGUFLoader {
-    pub fn from_file(path: &str) -> Result<Self, String> {
+    pub fn from_file(path: impl AsRef<std::path::Path>) -> Result<Self, String> {
         let file = File::open(path).map_err(|e| format!("Failed to open GGUF file: {}", e))?;
         let mmap = unsafe { Mmap::map(&file) }.map_err(|e| format!("Failed to mmap: {}", e))?;
         Self::from_mmap(mmap)
@@ -369,10 +411,12 @@ impl GGUFLoader {
             return Err(format!("Unsupported GGUF version: {}", version));
         }
 
-        let n_tensors = reader.read_u64()?;
-        let n_kv = reader.read_u64()?;
+        let n_tensors = usize::try_from(reader.read_u64()?)
+            .map_err(|_| "tensor count does not fit usize".to_string())?;
+        let n_kv = usize::try_from(reader.read_u64()?)
+            .map_err(|_| "metadata count does not fit usize".to_string())?;
 
-        let mut metadata = Vec::with_capacity(n_kv as usize);
+        let mut metadata = Vec::with_capacity(n_kv);
         for _ in 0..n_kv {
             let key = reader.read_string()?;
             let vtype_i32 = reader.read_i32()?;
@@ -382,11 +426,12 @@ impl GGUFLoader {
             metadata.push((key, value));
         }
 
-        let mut tensors = Vec::with_capacity(n_tensors as usize);
+        let mut tensors = Vec::with_capacity(n_tensors);
         for _ in 0..n_tensors {
             let name = reader.read_string()?;
-            let n_dims = reader.read_u32()?;
-            let mut dims = Vec::with_capacity(n_dims as usize);
+            let n_dims = usize::try_from(reader.read_u32()?)
+                .map_err(|_| "tensor dimension count does not fit usize".to_string())?;
+            let mut dims = Vec::with_capacity(n_dims);
             for _ in 0..n_dims {
                 dims.push(reader.read_u64()?);
             }
@@ -407,15 +452,44 @@ impl GGUFLoader {
             .find(|(k, _)| k == "general.alignment")
             .and_then(|(_, v)| v.to_u64())
             .unwrap_or(GGUF_DEFAULT_ALIGNMENT);
+        if alignment == 0 {
+            return Err("GGUF alignment must be nonzero".into());
+        }
+        let alignment = usize::try_from(alignment)
+            .map_err(|_| "GGUF alignment does not fit usize".to_string())?;
 
         let data_offset = reader.pos();
-        let padded_data_offset =
-            ((data_offset as u64 + alignment - 1) / alignment * alignment) as usize;
+        let remainder = data_offset % alignment;
+        let padded_data_offset = if remainder == 0 {
+            data_offset
+        } else {
+            data_offset
+                .checked_add(alignment - remainder)
+                .ok_or_else(|| "GGUF data offset overflow".to_string())?
+        };
+
+        for tensor in &tensors {
+            let offset = usize::try_from(tensor.offset)
+                .map_err(|_| format!("tensor {} offset does not fit usize", tensor.name))?;
+            let nbytes = usize::try_from(
+                tensor
+                    .checked_nbytes()
+                    .ok_or_else(|| format!("invalid tensor shape: {}", tensor.name))?,
+            )
+            .map_err(|_| format!("tensor {} byte size does not fit usize", tensor.name))?;
+            let end = padded_data_offset
+                .checked_add(offset)
+                .and_then(|start| start.checked_add(nbytes))
+                .ok_or_else(|| format!("tensor {} range overflow", tensor.name))?;
+            if end > mmap.len() {
+                return Err(format!("tensor {} exceeds GGUF data", tensor.name));
+            }
+        }
 
         Ok(Self {
             mmap,
             version,
-            alignment,
+            alignment: alignment as u64,
             data_offset: padded_data_offset,
             metadata,
             tensors,
@@ -436,6 +510,10 @@ impl GGUFLoader {
 
     pub fn tensors(&self) -> &[TensorInfo] {
         &self.tensors
+    }
+
+    pub fn metadata_entries(&self) -> &[(String, MetaValue)] {
+        &self.metadata
     }
 
     pub fn metadata(&self, key: &str) -> Option<&MetaValue> {
@@ -462,57 +540,98 @@ impl GGUFLoader {
 
     pub fn tensor_slice(&self, name: &str) -> Option<&[u8]> {
         let tensor = self.tensor_info(name)?;
-        let abs_offset = self.data_offset + tensor.offset as usize;
-        let nbytes = tensor.nbytes();
-        if abs_offset + nbytes <= self.mmap.len() {
-            Some(&self.mmap[abs_offset..abs_offset + nbytes])
-        } else {
-            None
-        }
+        let abs_offset = self
+            .data_offset
+            .checked_add(usize::try_from(tensor.offset).ok()?)?;
+        let nbytes = usize::try_from(tensor.checked_nbytes()?).ok()?;
+        let end = abs_offset.checked_add(nbytes)?;
+        self.mmap.get(abs_offset..end)
     }
 
     pub fn model_config(&self) -> Result<ModelConfig, String> {
-        let arch = self
-            .metadata("general.architecture")
-            .and_then(|v| v.to_string_val())
-            .unwrap_or_default();
+        model_config_from_source(self)
+    }
+}
 
-        let prefix = match &arch as &str {
-            "qwen2" | "qwen3" | "qwen35" | "llama" => arch,
-            _ => return Err(format!("Unsupported architecture: {}", arch)),
-        };
+pub trait TensorSource: Send + Sync {
+    fn metadata(&self, key: &str) -> Option<&MetaValue>;
+    fn tensor_info(&self, name: &str) -> Option<&TensorInfo>;
+    fn tensor_slice(&self, name: &str) -> Option<&[u8]>;
 
-        let get_u64 = |key: &str| -> Result<u64, String> {
-            self.metadata(key)
-                .and_then(|v| v.to_u64())
-                .ok_or_else(|| format!("Missing metadata: {}", key))
-        };
+    fn model_config(&self) -> Result<ModelConfig, String> {
+        model_config_from_source(self)
+    }
+}
 
-        let get_f64 = |key: &str| -> Result<f64, String> {
-            self.metadata(key)
-                .and_then(|v| v.to_f64())
-                .ok_or_else(|| format!("Missing metadata: {}", key))
-        };
+pub fn model_config_from_source<S: TensorSource + ?Sized>(
+    source: &S,
+) -> Result<ModelConfig, String> {
+    let arch = source
+        .metadata("general.architecture")
+        .and_then(MetaValue::to_string_val)
+        .unwrap_or_default();
+    let prefix = match arch {
+        "qwen2" | "qwen3" | "qwen35" | "llama" => arch,
+        _ => return Err(format!("Unsupported architecture: {arch}")),
+    };
+    let get_u64 = |key: &str| -> Result<u64, String> {
+        source
+            .metadata(key)
+            .and_then(MetaValue::to_u64)
+            .ok_or_else(|| format!("Missing metadata: {key}"))
+    };
+    let get_f64 = |key: &str| -> Result<f64, String> {
+        source
+            .metadata(key)
+            .and_then(MetaValue::to_f64)
+            .ok_or_else(|| format!("Missing metadata: {key}"))
+    };
+    let n_embd = usize::try_from(get_u64(&format!("{prefix}.embedding_length"))?)
+        .map_err(|_| format!("{prefix}.embedding_length does not fit usize"))?;
+    let n_head = usize::try_from(get_u64(&format!("{prefix}.attention.head_count"))?)
+        .map_err(|_| format!("{prefix}.attention.head_count does not fit usize"))?;
+    if n_head == 0 || n_embd % n_head != 0 {
+        return Err(format!(
+            "Invalid {prefix} head shape: embedding_length={n_embd}, head_count={n_head}"
+        ));
+    }
+    let as_usize = |key: String| -> Result<usize, String> {
+        usize::try_from(get_u64(&key)?).map_err(|_| format!("{key} does not fit usize"))
+    };
 
-        let n_embd = get_u64(&format!("{}.embedding_length", prefix))? as usize;
-        let n_head = get_u64(&format!("{}.attention.head_count", prefix))? as usize;
+    Ok(ModelConfig {
+        n_embd,
+        n_layer: as_usize(format!("{prefix}.block_count"))?,
+        n_head,
+        n_head_kv: as_usize(format!("{prefix}.attention.head_count_kv"))?,
+        n_embd_head: n_embd / n_head,
+        n_ff: as_usize(format!("{prefix}.feed_forward_length"))?,
+        n_ctx: as_usize(format!("{prefix}.context_length"))?,
+        vocab_size: match get_u64(&format!("{prefix}.vocab_size")) {
+            Ok(value) => usize::try_from(value)
+                .map_err(|_| format!("{prefix}.vocab_size does not fit usize"))?,
+            Err(_) => source
+                .metadata("tokenizer.ggml.tokens")
+                .and_then(MetaValue::to_arr)
+                .map(Vec::len)
+                .unwrap_or(0),
+        },
+        rope_freq_base: get_f64(&format!("{prefix}.rope.freq_base"))? as f32,
+        norm_eps: get_f64(&format!("{prefix}.attention.layer_norm_rms_epsilon"))? as f32,
+    })
+}
 
-        Ok(ModelConfig {
-            n_embd,
-            n_layer: get_u64(&format!("{}.block_count", prefix))? as usize,
-            n_head,
-            n_head_kv: get_u64(&format!("{}.attention.head_count_kv", prefix))? as usize,
-            n_embd_head: n_embd / n_head,
-            n_ff: get_u64(&format!("{}.feed_forward_length", prefix))? as usize,
-            n_ctx: get_u64(&format!("{}.context_length", prefix))? as usize,
-            vocab_size: get_u64(&format!("{}.vocab_size", prefix)).unwrap_or_else(|_| {
-                self.metadata("tokenizer.ggml.tokens")
-                    .and_then(|v| v.to_arr().map(|a| a.len()))
-                    .unwrap_or(0) as u64
-            }) as usize,
-            rope_freq_base: get_f64(&format!("{}.rope.freq_base", prefix))? as f32,
-            norm_eps: get_f64(&format!("{}.attention.layer_norm_rms_epsilon", prefix))? as f32,
-        })
+impl TensorSource for GGUFLoader {
+    fn metadata(&self, key: &str) -> Option<&MetaValue> {
+        GGUFLoader::metadata(self, key)
+    }
+
+    fn tensor_info(&self, name: &str) -> Option<&TensorInfo> {
+        GGUFLoader::tensor_info(self, name)
+    }
+
+    fn tensor_slice(&self, name: &str) -> Option<&[u8]> {
+        GGUFLoader::tensor_slice(self, name)
     }
 }
 
@@ -542,16 +661,16 @@ impl<'a> QuantizedLinear<'a> {
         }
     }
 
-    pub fn from_gguf(
-        loader: &'a GGUFLoader,
+    pub fn from_source<S: TensorSource + ?Sized>(
+        source: &'a S,
         weight_name: &str,
         bias_name: Option<&str>,
         in_features: usize,
         out_features: usize,
         name: &'a str,
     ) -> Option<Self> {
-        let weight = loader.tensor_slice(weight_name)?;
-        let bias = bias_name.and_then(|n| loader.tensor_slice(n));
+        let weight = source.tensor_slice(weight_name)?;
+        let bias = bias_name.and_then(|n| source.tensor_slice(n));
         Some(Self {
             weight,
             bias,
@@ -663,22 +782,45 @@ impl<'a> ModelGraph<'a> {
 mod tests {
     use super::*;
 
-    fn push_u8(buf: &mut Vec<u8>, v: u8) { buf.push(v); }
-    fn push_u16(buf: &mut Vec<u8>, v: u16) { buf.extend_from_slice(&v.to_le_bytes()); }
-    fn push_i16(buf: &mut Vec<u8>, v: i16) { buf.extend_from_slice(&v.to_le_bytes()); }
-    fn push_u32(buf: &mut Vec<u8>, v: u32) { buf.extend_from_slice(&v.to_le_bytes()); }
-    fn push_i32(buf: &mut Vec<u8>, v: i32) { buf.extend_from_slice(&v.to_le_bytes()); }
-    fn push_u64(buf: &mut Vec<u8>, v: u64) { buf.extend_from_slice(&v.to_le_bytes()); }
-    fn push_i64(buf: &mut Vec<u8>, v: i64) { buf.extend_from_slice(&v.to_le_bytes()); }
-    fn push_f32(buf: &mut Vec<u8>, v: f32) { buf.extend_from_slice(&v.to_le_bytes()); }
-    fn push_f64(buf: &mut Vec<u8>, v: f64) { buf.extend_from_slice(&v.to_le_bytes()); }
+    fn push_u8(buf: &mut Vec<u8>, v: u8) {
+        buf.push(v);
+    }
+    fn push_u16(buf: &mut Vec<u8>, v: u16) {
+        buf.extend_from_slice(&v.to_le_bytes());
+    }
+    fn push_i16(buf: &mut Vec<u8>, v: i16) {
+        buf.extend_from_slice(&v.to_le_bytes());
+    }
+    fn push_u32(buf: &mut Vec<u8>, v: u32) {
+        buf.extend_from_slice(&v.to_le_bytes());
+    }
+    fn push_i32(buf: &mut Vec<u8>, v: i32) {
+        buf.extend_from_slice(&v.to_le_bytes());
+    }
+    fn push_u64(buf: &mut Vec<u8>, v: u64) {
+        buf.extend_from_slice(&v.to_le_bytes());
+    }
+    fn push_i64(buf: &mut Vec<u8>, v: i64) {
+        buf.extend_from_slice(&v.to_le_bytes());
+    }
+    fn push_f32(buf: &mut Vec<u8>, v: f32) {
+        buf.extend_from_slice(&v.to_le_bytes());
+    }
+    fn push_f64(buf: &mut Vec<u8>, v: f64) {
+        buf.extend_from_slice(&v.to_le_bytes());
+    }
 
     fn push_str(buf: &mut Vec<u8>, s: &str) {
         push_u64(buf, s.len() as u64);
         buf.extend_from_slice(s.as_bytes());
     }
 
-    fn push_kv(buf: &mut Vec<u8>, key: &str, vtype: MetaValueType, write_val: impl FnOnce(&mut Vec<u8>)) {
+    fn push_kv(
+        buf: &mut Vec<u8>,
+        key: &str,
+        vtype: MetaValueType,
+        write_val: impl FnOnce(&mut Vec<u8>),
+    ) {
         push_str(buf, key);
         push_i32(buf, vtype as i32);
         write_val(buf);
@@ -689,13 +831,59 @@ mod tests {
         push_u32(&mut b, u32::from_le_bytes(*b"GGUF"));
         push_u32(&mut b, 3);
         push_u64(&mut b, 2);
-        push_u64(&mut b, 5);
+        push_u64(&mut b, 11);
 
-        push_kv(&mut b, "general.architecture", MetaValueType::String, |b| push_str(b, "qwen2"));
-        push_kv(&mut b, "qwen2.embedding_length", MetaValueType::Uint32, |b| push_u32(b, 1024));
-        push_kv(&mut b, "qwen2.block_count", MetaValueType::Uint32, |b| push_u32(b, 24));
-        push_kv(&mut b, "qwen2.attention.head_count", MetaValueType::Uint32, |b| push_u32(b, 16));
-        push_kv(&mut b, "general.alignment", MetaValueType::Uint64, |b| push_u64(b, 32));
+        push_kv(&mut b, "general.architecture", MetaValueType::String, |b| {
+            push_str(b, "qwen2")
+        });
+        push_kv(
+            &mut b,
+            "qwen2.embedding_length",
+            MetaValueType::Uint32,
+            |b| push_u32(b, 1024),
+        );
+        push_kv(&mut b, "qwen2.block_count", MetaValueType::Uint32, |b| {
+            push_u32(b, 24)
+        });
+        push_kv(
+            &mut b,
+            "qwen2.attention.head_count",
+            MetaValueType::Uint32,
+            |b| push_u32(b, 16),
+        );
+        push_kv(&mut b, "general.alignment", MetaValueType::Uint64, |b| {
+            push_u64(b, 32)
+        });
+        push_kv(
+            &mut b,
+            "qwen2.attention.head_count_kv",
+            MetaValueType::Uint32,
+            |b| push_u32(b, 16),
+        );
+        push_kv(
+            &mut b,
+            "qwen2.feed_forward_length",
+            MetaValueType::Uint32,
+            |b| push_u32(b, 2816),
+        );
+        push_kv(&mut b, "qwen2.context_length", MetaValueType::Uint32, |b| {
+            push_u32(b, 4096)
+        });
+        push_kv(&mut b, "qwen2.vocab_size", MetaValueType::Uint32, |b| {
+            push_u32(b, 151936)
+        });
+        push_kv(
+            &mut b,
+            "qwen2.rope.freq_base",
+            MetaValueType::Float32,
+            |b| push_f32(b, 1_000_000.0),
+        );
+        push_kv(
+            &mut b,
+            "qwen2.attention.layer_norm_rms_epsilon",
+            MetaValueType::Float32,
+            |b| push_f32(b, 1e-6),
+        );
 
         push_str(&mut b, "token_embd.weight");
         push_u32(&mut b, 2);
@@ -713,7 +901,9 @@ mod tests {
         let padded = ((embd_nbytes as u64 + 31) / 32 * 32) as u64;
         push_u64(&mut b, padded);
 
-        while b.len() % 32 != 0 { b.push(0); }
+        while b.len() % 32 != 0 {
+            b.push(0);
+        }
         let data_start = b.len();
         let total_data = padded as usize + GGMLType::Q4K.nbytes(1024 * 1024);
         b.resize(data_start + total_data, 0xAB);
@@ -727,18 +917,40 @@ mod tests {
         push_u64(&mut b, 0);
         push_u64(&mut b, 13);
 
-        push_kv(&mut b, "test.uint8", MetaValueType::Uint8, |b| push_u8(b, 42));
-        push_kv(&mut b, "test.int8", MetaValueType::Int8, |b| push_u8(b, (-1i8) as u8));
-        push_kv(&mut b, "test.uint16", MetaValueType::Uint16, |b| push_u16(b, 1000));
-        push_kv(&mut b, "test.int16", MetaValueType::Int16, |b| push_i16(b, -100));
-        push_kv(&mut b, "test.uint32", MetaValueType::Uint32, |b| push_u32(b, 1024));
-        push_kv(&mut b, "test.int32", MetaValueType::Int32, |b| push_i32(b, -24));
-        push_kv(&mut b, "test.float32", MetaValueType::Float32, |b| push_f32(b, 3.14));
+        push_kv(&mut b, "test.uint8", MetaValueType::Uint8, |b| {
+            push_u8(b, 42)
+        });
+        push_kv(&mut b, "test.int8", MetaValueType::Int8, |b| {
+            push_u8(b, (-1i8) as u8)
+        });
+        push_kv(&mut b, "test.uint16", MetaValueType::Uint16, |b| {
+            push_u16(b, 1000)
+        });
+        push_kv(&mut b, "test.int16", MetaValueType::Int16, |b| {
+            push_i16(b, -100)
+        });
+        push_kv(&mut b, "test.uint32", MetaValueType::Uint32, |b| {
+            push_u32(b, 1024)
+        });
+        push_kv(&mut b, "test.int32", MetaValueType::Int32, |b| {
+            push_i32(b, -24)
+        });
+        push_kv(&mut b, "test.float32", MetaValueType::Float32, |b| {
+            push_f32(b, 3.14)
+        });
         push_kv(&mut b, "test.bool", MetaValueType::Bool, |b| push_u8(b, 1));
-        push_kv(&mut b, "test.string", MetaValueType::String, |b| push_str(b, "hello"));
-        push_kv(&mut b, "test.uint64", MetaValueType::Uint64, |b| push_u64(b, 999999));
-        push_kv(&mut b, "test.int64", MetaValueType::Int64, |b| push_i64(b, -123456));
-        push_kv(&mut b, "test.float64", MetaValueType::Float64, |b| push_f64(b, 2.71828));
+        push_kv(&mut b, "test.string", MetaValueType::String, |b| {
+            push_str(b, "hello")
+        });
+        push_kv(&mut b, "test.uint64", MetaValueType::Uint64, |b| {
+            push_u64(b, 999999)
+        });
+        push_kv(&mut b, "test.int64", MetaValueType::Int64, |b| {
+            push_i64(b, -123456)
+        });
+        push_kv(&mut b, "test.float64", MetaValueType::Float64, |b| {
+            push_f64(b, 2.71828)
+        });
         push_kv(&mut b, "test.array", MetaValueType::Array, |b| {
             push_i32(b, MetaValueType::Uint32 as i32);
             push_u64(b, 3);
@@ -747,7 +959,9 @@ mod tests {
             push_u32(b, 30);
         });
 
-        while b.len() % 32 != 0 { b.push(0); }
+        while b.len() % 32 != 0 {
+            b.push(0);
+        }
         b
     }
 
@@ -770,12 +984,25 @@ mod tests {
         assert_eq!(loader.version, 3);
         assert_eq!(loader.alignment, 32);
         assert_eq!(loader.n_tensors(), 2);
-        assert_eq!(loader.n_kv(), 5);
+        assert_eq!(loader.n_kv(), 11);
 
-        let arch = loader.metadata("general.architecture").and_then(|v| v.to_string_val()).unwrap();
+        let arch = loader
+            .metadata("general.architecture")
+            .and_then(|v| v.to_string_val())
+            .unwrap();
         assert_eq!(arch, "qwen2");
-        assert_eq!(loader.metadata("qwen2.embedding_length").and_then(|v| v.to_u64()), Some(1024));
-        assert_eq!(loader.metadata("qwen2.block_count").and_then(|v| v.to_u64()), Some(24));
+        assert_eq!(
+            loader
+                .metadata("qwen2.embedding_length")
+                .and_then(|v| v.to_u64()),
+            Some(1024)
+        );
+        assert_eq!(
+            loader
+                .metadata("qwen2.block_count")
+                .and_then(|v| v.to_u64()),
+            Some(24)
+        );
 
         let ti0 = loader.tensor_info("token_embd.weight").expect("tensor 0");
         assert_eq!(ti0.dims, vec![1024, 151936]);
@@ -791,31 +1018,98 @@ mod tests {
         assert_eq!(s1.len(), ti1.nbytes());
     }
 
+    struct DelegatingSource<'a>(&'a GGUFLoader);
+
+    impl TensorSource for DelegatingSource<'_> {
+        fn metadata(&self, key: &str) -> Option<&MetaValue> {
+            self.0.metadata(key)
+        }
+
+        fn tensor_info(&self, name: &str) -> Option<&TensorInfo> {
+            self.0.tensor_info(name)
+        }
+
+        fn tensor_slice(&self, name: &str) -> Option<&[u8]> {
+            self.0.tensor_slice(name)
+        }
+    }
+
+    #[test]
+    fn model_config_and_linear_accept_a_tensor_source() {
+        let loader = parse_temp(&build_minimal_gguf()).unwrap();
+        let source = DelegatingSource(&loader);
+        assert_eq!(source.model_config().unwrap().n_embd, 1024);
+        assert!(QuantizedLinear::from_source(
+            &source,
+            "blk.0.attn_q.weight",
+            None,
+            1024,
+            1024,
+            "attn_q",
+        )
+        .is_some());
+    }
+
     #[test]
     fn test_gguf_all_meta_types() {
         let data = build_all_meta_types_gguf();
         let loader = parse_temp(&data).expect("parse all meta types");
 
-        assert_eq!(loader.metadata("test.uint8").and_then(|v| v.to_u64()), Some(42));
-        assert_eq!(loader.metadata("test.int8").and_then(|v| v.to_u64()), Some((-1i8) as u64));
-        assert_eq!(loader.metadata("test.uint16").and_then(|v| v.to_u64()), Some(1000));
-        assert_eq!(loader.metadata("test.int16").and_then(|v| v.to_u64()), Some((-100i16) as u64));
-        assert_eq!(loader.metadata("test.uint32").and_then(|v| v.to_u64()), Some(1024));
-        assert_eq!(loader.metadata("test.int32").and_then(|v| v.to_u64()), Some((-24i32) as u64));
+        assert_eq!(
+            loader.metadata("test.uint8").and_then(|v| v.to_u64()),
+            Some(42)
+        );
+        assert_eq!(
+            loader.metadata("test.int8").and_then(|v| v.to_u64()),
+            Some((-1i8) as u64)
+        );
+        assert_eq!(
+            loader.metadata("test.uint16").and_then(|v| v.to_u64()),
+            Some(1000)
+        );
+        assert_eq!(
+            loader.metadata("test.int16").and_then(|v| v.to_u64()),
+            Some((-100i16) as u64)
+        );
+        assert_eq!(
+            loader.metadata("test.uint32").and_then(|v| v.to_u64()),
+            Some(1024)
+        );
+        assert_eq!(
+            loader.metadata("test.int32").and_then(|v| v.to_u64()),
+            Some((-24i32) as u64)
+        );
 
-        let f32v = loader.metadata("test.float32").and_then(|v| v.to_f64()).unwrap();
+        let f32v = loader
+            .metadata("test.float32")
+            .and_then(|v| v.to_f64())
+            .unwrap();
         assert!((f32v - 3.14).abs() < 0.01);
 
         match loader.metadata("test.bool") {
-            Some(MetaValue::Bool(true)) => {},
+            Some(MetaValue::Bool(true)) => {}
             other => panic!("expected Bool(true), got {:?}", other),
         }
 
-        assert_eq!(loader.metadata("test.string").and_then(|v| v.to_string_val()), Some("hello"));
-        assert_eq!(loader.metadata("test.uint64").and_then(|v| v.to_u64()), Some(999999));
-        assert_eq!(loader.metadata("test.int64").and_then(|v| v.to_u64()), Some((-123456i64) as u64));
+        assert_eq!(
+            loader
+                .metadata("test.string")
+                .and_then(|v| v.to_string_val()),
+            Some("hello")
+        );
+        assert_eq!(
+            loader.metadata("test.uint64").and_then(|v| v.to_u64()),
+            Some(999999)
+        );
+        assert_eq!(
+            loader.metadata("test.int64").and_then(|v| v.to_u64()),
+            Some((-123456i64) as u64)
+        );
 
-        let f64v = loader.metadata("test.float64").and_then(|v| v.to_f64()).unwrap();
+        let f64v = loader
+            .metadata("test.float64")
+            .and_then(|v| v.to_f64())
+            .unwrap();
         assert!((f64v - 2.71828).abs() < 0.001);
 
         match loader.metadata("test.array") {
@@ -825,7 +1119,7 @@ mod tests {
                 assert_eq!(vals[0].to_u64(), Some(10));
                 assert_eq!(vals[1].to_u64(), Some(20));
                 assert_eq!(vals[2].to_u64(), Some(30));
-            },
+            }
             other => panic!("expected Array, got {:?}", other),
         }
     }
@@ -838,6 +1132,36 @@ mod tests {
         assert_eq!(GGMLType::Q4K.nbytes(512), 288);
         assert_eq!(GGMLType::Q4_0.nbytes(32), 18);
         assert_eq!(GGMLType::Q8_0.nbytes(32), 34);
+    }
+
+    #[test]
+    fn k_quant_block_sizes_match_ggml() {
+        assert_eq!(GGMLType::Q2K.nbytes(256), 84);
+        assert_eq!(GGMLType::Q3K.nbytes(256), 110);
+    }
+
+    #[test]
+    fn tensor_size_overflow_is_rejected() {
+        let info = TensorInfo {
+            name: "bad".into(),
+            dims: vec![u64::MAX, 2],
+            ggml_type: GGMLType::F32,
+            offset: 0,
+        };
+        assert_eq!(info.checked_n_elements(), None);
+        assert_eq!(info.checked_nbytes(), None);
+    }
+
+    #[test]
+    fn malformed_bool_and_utf8_are_rejected() {
+        let mut bad_bool = ByteReader::new(&[2]);
+        assert!(bad_bool.read_meta_value(MetaValueType::Bool).is_err());
+
+        let mut encoded = Vec::new();
+        push_u64(&mut encoded, 1);
+        encoded.push(0xFF);
+        let mut bad_string = ByteReader::new(&encoded);
+        assert!(bad_string.read_string().is_err());
     }
 
     #[test]

--- a/RustModelInference/src/model.rs
+++ b/RustModelInference/src/model.rs
@@ -378,7 +378,9 @@ impl<'a> ByteReader<'a> {
                     MetaValueType::Uint32 | MetaValueType::Int32 | MetaValueType::Float32 => 4,
                     MetaValueType::Uint64 | MetaValueType::Int64 | MetaValueType::Float64 => 8,
                     MetaValueType::String => 8,
-                    MetaValueType::Array => 12,
+                    MetaValueType::Array => {
+                        return Err("Nested metadata arrays are not supported".into())
+                    }
                 };
                 self.ensure_count(n, minimum_item_bytes, "array")?;
                 let mut vals = Self::try_vec(n, "array values")?;
@@ -1208,6 +1210,35 @@ mod tests {
     }
 
     #[test]
+    fn nested_metadata_arrays_are_rejected_before_recursive_decode() {
+        let mut encoded = Vec::new();
+        push_u32(&mut encoded, u32::from_le_bytes(*b"GGUF"));
+        push_u32(&mut encoded, 3);
+        push_u64(&mut encoded, 0);
+        push_u64(&mut encoded, 1);
+        push_kv(
+            &mut encoded,
+            "test.nested",
+            MetaValueType::Array,
+            |encoded| {
+                push_i32(encoded, MetaValueType::Array as i32);
+                push_u64(encoded, 1);
+                push_i32(encoded, MetaValueType::Uint32 as i32);
+                push_u64(encoded, 1);
+                push_u32(encoded, 7);
+            },
+        );
+        while encoded.len() % 32 != 0 {
+            encoded.push(0);
+        }
+
+        assert_eq!(
+            parse_temp(&encoded).unwrap_err(),
+            "Nested metadata arrays are not supported"
+        );
+    }
+
+    #[test]
     fn metadata_count_must_fit_remaining_data() {
         let mut encoded = Vec::new();
         push_u32(&mut encoded, u32::from_le_bytes(*b"GGUF"));
@@ -1215,7 +1246,10 @@ mod tests {
         push_u64(&mut encoded, 0);
         push_u64(&mut encoded, 1);
         let err = parse_temp(&encoded).unwrap_err();
-        assert!(err.contains("metadata count exceeds remaining bytes"), "{err}");
+        assert!(
+            err.contains("metadata count exceeds remaining bytes"),
+            "{err}"
+        );
     }
 
     #[test]
@@ -1226,7 +1260,10 @@ mod tests {
         push_u64(&mut encoded, 1);
         push_u64(&mut encoded, 0);
         let err = parse_temp(&encoded).unwrap_err();
-        assert!(err.contains("tensor count exceeds remaining bytes"), "{err}");
+        assert!(
+            err.contains("tensor count exceeds remaining bytes"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/RustModelInference/src/model.rs
+++ b/RustModelInference/src/model.rs
@@ -257,6 +257,26 @@ impl<'a> ByteReader<'a> {
         self.data.len().saturating_sub(self.pos)
     }
 
+    fn ensure_count(
+        &self,
+        count: usize,
+        minimum_item_bytes: usize,
+        context: &str,
+    ) -> Result<(), String> {
+        if count > self.remaining() / minimum_item_bytes {
+            return Err(format!("{context} count exceeds remaining bytes"));
+        }
+        Ok(())
+    }
+
+    fn try_vec<T>(count: usize, context: &str) -> Result<Vec<T>, String> {
+        let mut values = Vec::new();
+        values
+            .try_reserve_exact(count)
+            .map_err(|_| format!("failed to allocate {context}"))?;
+        Ok(values)
+    }
+
     fn read_u8(&mut self) -> Result<u8, String> {
         if self.remaining() < 1 {
             return Err("EOF reading u8".into());
@@ -352,7 +372,16 @@ impl<'a> ByteReader<'a> {
                 let elem_type = MetaValueType::from_i32(elem_type_i32)
                     .ok_or_else(|| format!("Unknown meta value type: {}", elem_type_i32))?;
                 let n = self.read_len("array")?;
-                let mut vals = Vec::with_capacity(n);
+                let minimum_item_bytes = match elem_type {
+                    MetaValueType::Uint8 | MetaValueType::Int8 | MetaValueType::Bool => 1,
+                    MetaValueType::Uint16 | MetaValueType::Int16 => 2,
+                    MetaValueType::Uint32 | MetaValueType::Int32 | MetaValueType::Float32 => 4,
+                    MetaValueType::Uint64 | MetaValueType::Int64 | MetaValueType::Float64 => 8,
+                    MetaValueType::String => 8,
+                    MetaValueType::Array => 12,
+                };
+                self.ensure_count(n, minimum_item_bytes, "array")?;
+                let mut vals = Self::try_vec(n, "array values")?;
                 for _ in 0..n {
                     vals.push(self.read_meta_value(elem_type)?);
                 }
@@ -416,7 +445,8 @@ impl GGUFLoader {
         let n_kv = usize::try_from(reader.read_u64()?)
             .map_err(|_| "metadata count does not fit usize".to_string())?;
 
-        let mut metadata = Vec::with_capacity(n_kv);
+        reader.ensure_count(n_kv, 13, "metadata")?;
+        let mut metadata = ByteReader::try_vec(n_kv, "metadata entries")?;
         for _ in 0..n_kv {
             let key = reader.read_string()?;
             let vtype_i32 = reader.read_i32()?;
@@ -426,12 +456,14 @@ impl GGUFLoader {
             metadata.push((key, value));
         }
 
-        let mut tensors = Vec::with_capacity(n_tensors);
+        reader.ensure_count(n_tensors, 24, "tensor")?;
+        let mut tensors = ByteReader::try_vec(n_tensors, "tensor entries")?;
         for _ in 0..n_tensors {
             let name = reader.read_string()?;
             let n_dims = usize::try_from(reader.read_u32()?)
                 .map_err(|_| "tensor dimension count does not fit usize".to_string())?;
-            let mut dims = Vec::with_capacity(n_dims);
+            reader.ensure_count(n_dims, 8, "tensor dimension")?;
+            let mut dims = ByteReader::try_vec(n_dims, "tensor dimensions")?;
             for _ in 0..n_dims {
                 dims.push(reader.read_u64()?);
             }
@@ -1162,6 +1194,56 @@ mod tests {
         encoded.push(0xFF);
         let mut bad_string = ByteReader::new(&encoded);
         assert!(bad_string.read_string().is_err());
+    }
+
+    #[test]
+    fn metadata_array_count_must_fit_remaining_data() {
+        let mut encoded = Vec::new();
+        push_i32(&mut encoded, MetaValueType::Uint8 as i32);
+        push_u64(&mut encoded, 2);
+        let err = ByteReader::new(&encoded)
+            .read_meta_value(MetaValueType::Array)
+            .unwrap_err();
+        assert!(err.contains("array count exceeds remaining bytes"), "{err}");
+    }
+
+    #[test]
+    fn metadata_count_must_fit_remaining_data() {
+        let mut encoded = Vec::new();
+        push_u32(&mut encoded, u32::from_le_bytes(*b"GGUF"));
+        push_u32(&mut encoded, 3);
+        push_u64(&mut encoded, 0);
+        push_u64(&mut encoded, 1);
+        let err = parse_temp(&encoded).unwrap_err();
+        assert!(err.contains("metadata count exceeds remaining bytes"), "{err}");
+    }
+
+    #[test]
+    fn tensor_count_must_fit_remaining_data() {
+        let mut encoded = Vec::new();
+        push_u32(&mut encoded, u32::from_le_bytes(*b"GGUF"));
+        push_u32(&mut encoded, 3);
+        push_u64(&mut encoded, 1);
+        push_u64(&mut encoded, 0);
+        let err = parse_temp(&encoded).unwrap_err();
+        assert!(err.contains("tensor count exceeds remaining bytes"), "{err}");
+    }
+
+    #[test]
+    fn tensor_dimension_count_must_fit_remaining_data() {
+        let mut encoded = Vec::new();
+        push_u32(&mut encoded, u32::from_le_bytes(*b"GGUF"));
+        push_u32(&mut encoded, 3);
+        push_u64(&mut encoded, 1);
+        push_u64(&mut encoded, 0);
+        push_str(&mut encoded, "");
+        push_u32(&mut encoded, 2);
+        encoded.extend_from_slice(&[0; 12]);
+        let err = parse_temp(&encoded).unwrap_err();
+        assert!(
+            err.contains("tensor dimension count exceeds remaining bytes"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/RustModelInference/src/ops.rs
+++ b/RustModelInference/src/ops.rs
@@ -1,6 +1,9 @@
 #[cfg(target_arch = "x86_64")]
 use std::sync::atomic::{AtomicBool, Ordering};
 
+#[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+use std::arch::asm;
+
 #[cfg(target_arch = "x86_64")]
 static HAS_AVX2_FMA: AtomicBool = AtomicBool::new(false);
 #[cfg(target_arch = "x86_64")]
@@ -391,33 +394,64 @@ pub fn dot_f16_f32(a: &[f32], b_f16: &[u16], n: usize) -> f32 {
 
 pub fn dot_f16_f16_bytes(a: &[u16], b: &[u8], n: usize) -> f32 {
     debug_assert!(a.len() >= n && b.len() >= n * 2);
-    #[cfg(target_arch = "aarch64")]
-    if n % 32 == 0 {
-        let mut sums = [[half::f16::from_f32(0.0); 8]; 4];
-        for offset in (0..n).step_by(32) {
-            for (group, sum) in sums.iter_mut().enumerate() {
-                for lane in 0..8 {
-                    let index = offset + group * 8 + lane;
-                    let weight =
-                        u16::from_le_bytes(b[index * 2..index * 2 + 2].try_into().unwrap());
-                    sum[lane] = half::f16::from_f32(
-                        f16_to_f32(a[index]).mul_add(f16_to_f32(weight), sum[lane].to_f32()),
-                    );
-                }
-            }
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+    let (mut sum, tail_start) = {
+        let prefix = n & !31;
+        if prefix > 0 && std::arch::is_aarch64_feature_detected!("fp16") {
+            (
+                f64::from(unsafe { dot_f16_f16_fp16_neon(a.as_ptr(), b.as_ptr(), prefix) }),
+                prefix,
+            )
+        } else {
+            (0.0, 0)
         }
-        for lane in 0..8 {
-            sums[0][lane] = half::f16::from_f32(sums[0][lane].to_f32() + sums[2][lane].to_f32());
-            sums[1][lane] = half::f16::from_f32(sums[1][lane].to_f32() + sums[3][lane].to_f32());
-            sums[0][lane] = half::f16::from_f32(sums[0][lane].to_f32() + sums[1][lane].to_f32());
-        }
-        return sums[0].iter().map(|value| value.to_f32()).sum();
+    };
+    #[cfg(not(all(target_arch = "aarch64", target_endian = "little")))]
+    let (mut sum, tail_start) = (0.0f64, 0usize);
+    for index in tail_start..n {
+        let weight = u16::from_le_bytes(b[index * 2..index * 2 + 2].try_into().unwrap());
+        sum += f64::from(f16_to_f32(a[index]) * f16_to_f32(weight));
     }
-    a[..n]
-        .iter()
-        .zip(b[..n * 2].chunks_exact(2))
-        .map(|(&x, y)| f16_to_f32(x) * f16_to_f32(u16::from_le_bytes(y.try_into().unwrap())))
-        .sum()
+    sum as f32
+}
+
+#[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+unsafe fn dot_f16_f16_fp16_neon(x: *const u16, y: *const u8, n: usize) -> f32 {
+    debug_assert_eq!(n % 32, 0);
+    let bits: u32;
+    asm!(
+        "movi v0.8h, #0", "movi v1.8h, #0",
+        "movi v2.8h, #0", "movi v3.8h, #0",
+        "cbz {n}, 2f",
+        "1:",
+        "ld1 {{v4.8h-v7.8h}}, [{x}], #64",
+        "ld1 {{v16.8h-v19.8h}}, [{y}], #64",
+        "fmla v0.8h, v4.8h, v16.8h",
+        "fmla v1.8h, v5.8h, v17.8h",
+        "fmla v2.8h, v6.8h, v18.8h",
+        "fmla v3.8h, v7.8h, v19.8h",
+        "subs {n}, {n}, #32",
+        "b.ne 1b",
+        "2:",
+        "fadd v0.8h, v0.8h, v2.8h",
+        "fadd v1.8h, v1.8h, v3.8h",
+        "fadd v0.8h, v0.8h, v1.8h",
+        "fcvtl v4.4s, v0.4h",
+        "fcvtl2 v5.4s, v0.8h",
+        "fadd v4.4s, v4.4s, v5.4s",
+        "faddp v4.4s, v4.4s, v4.4s",
+        "faddp s4, v4.2s",
+        "fmov {bits:w}, s4",
+        x = inout(reg) x => _,
+        y = inout(reg) y => _,
+        n = inout(reg) n => _,
+        bits = lateout(reg) bits,
+        out("v0") _, out("v1") _, out("v2") _, out("v3") _,
+        out("v4") _, out("v5") _, out("v6") _, out("v7") _,
+        out("v16") _, out("v17") _, out("v18") _, out("v19") _,
+        options(nostack, readonly),
+    );
+    f32::from_bits(bits)
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -2160,6 +2194,52 @@ mod neon_tests {
 
         let expected_dot: f32 = src.iter().zip(&bits).map(|(x, h)| x * f16_to_f32(*h)).sum();
         assert_close(unsafe { dot_f16_f32_neon(&src, &bits, src.len()) }, expected_dot);
+    }
+
+    #[test]
+    fn f16_dot_dispatch_matches_native_or_scalar_reduction() {
+        fn pinned_inputs(n: usize) -> (Vec<u16>, Vec<u8>) {
+            let x = (0..n)
+                .map(|index| {
+                    ((if index % 3 == 0 { 0x8000 } else { 0 })
+                        | ((14 + index % 3) << 10)
+                        | ((index * 73 + 19) & 0x03ff)) as u16
+                })
+                .collect();
+            let mut y = Vec::with_capacity(n * 2);
+            for index in 0..n {
+                let bits = ((if matches!(index % 5, 1 | 2) { 0x8000 } else { 0 })
+                    | ((13 + index % 4) << 10)
+                    | ((index * 151 + 7) & 0x03ff)) as u16;
+                y.extend_from_slice(&bits.to_le_bytes());
+            }
+            (x, y)
+        }
+
+        #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+        let native_fp16 = std::arch::is_aarch64_feature_detected!("fp16");
+        #[cfg(not(all(target_arch = "aarch64", target_endian = "little")))]
+        let native_fp16 = false;
+        let expected = if native_fp16 {
+            [(32, 0xc086_b000), (37, 0x4035_3bf4), (64, 0x4122_9e00)]
+        } else {
+            [(32, 0xc086_612e), (37, 0x4035_d999), (64, 0x4122_a161)]
+        };
+        for (n, expected) in expected {
+            let (x, y) = pinned_inputs(n);
+            assert_eq!(dot_f16_f16_bytes(&x, &y, n).to_bits(), expected, "n={n}");
+        }
+
+        if !native_fp16 {
+            return;
+        }
+        let mut x = vec![0; 64];
+        let mut y = vec![0; 128];
+        x[0] = 0x3c00;
+        y[..2].copy_from_slice(&0x3c00u16.to_le_bytes());
+        x[32] = 0x0475;
+        y[64..66].copy_from_slice(&0x472eu16.to_le_bytes());
+        assert_eq!(dot_f16_f16_bytes(&x, &y, 64).to_bits(), 0x3f80_2000);
     }
 
     fn valid_q8_weights(n_in: usize, n_out: usize) -> Vec<u8> {

--- a/RustModelInference/src/ops.rs
+++ b/RustModelInference/src/ops.rs
@@ -389,6 +389,37 @@ pub fn dot_f16_f32(a: &[f32], b_f16: &[u16], n: usize) -> f32 {
     s
 }
 
+pub fn dot_f16_f16_bytes(a: &[u16], b: &[u8], n: usize) -> f32 {
+    debug_assert!(a.len() >= n && b.len() >= n * 2);
+    #[cfg(target_arch = "aarch64")]
+    if n % 32 == 0 {
+        let mut sums = [[half::f16::from_f32(0.0); 8]; 4];
+        for offset in (0..n).step_by(32) {
+            for (group, sum) in sums.iter_mut().enumerate() {
+                for lane in 0..8 {
+                    let index = offset + group * 8 + lane;
+                    let weight =
+                        u16::from_le_bytes(b[index * 2..index * 2 + 2].try_into().unwrap());
+                    sum[lane] = half::f16::from_f32(
+                        f16_to_f32(a[index]).mul_add(f16_to_f32(weight), sum[lane].to_f32()),
+                    );
+                }
+            }
+        }
+        for lane in 0..8 {
+            sums[0][lane] = half::f16::from_f32(sums[0][lane].to_f32() + sums[2][lane].to_f32());
+            sums[1][lane] = half::f16::from_f32(sums[1][lane].to_f32() + sums[3][lane].to_f32());
+            sums[0][lane] = half::f16::from_f32(sums[0][lane].to_f32() + sums[1][lane].to_f32());
+        }
+        return sums[0].iter().map(|value| value.to_f32()).sum();
+    }
+    a[..n]
+        .iter()
+        .zip(b[..n * 2].chunks_exact(2))
+        .map(|(&x, y)| f16_to_f32(x) * f16_to_f32(u16::from_le_bytes(y.try_into().unwrap())))
+        .sum()
+}
+
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
 unsafe fn dot_f16_f32_neon(a: &[f32], b: &[u16], n: usize) -> f32 {

--- a/RustModelInference/src/qwen35.rs
+++ b/RustModelInference/src/qwen35.rs
@@ -659,6 +659,7 @@ impl Qwen35Model {
             let n_cols = ti.dims[0] as usize;
             let n_rows = ti.dims[1] as usize;
             match ti.ggml_type {
+                GGMLType::F16 => (0..n_cols * n_rows).map(|i| f16_at(data, i)).collect(),
                 GGMLType::Q8_0 => quant::dequant_q80_weight(data, n_cols, n_rows),
                 GGMLType::Q6K => quant::dequant_q6k_weight(data, n_cols, n_rows),
                 _ => return Err("Unsupported token_embd type".into()),
@@ -1669,6 +1670,23 @@ mod tests {
         assert_eq!(
             source.tensor_info("token_embd.weight").unwrap().ggml_type,
             GGMLType::Q8_0,
+        );
+        Qwen35Model::from_source(source.as_ref()).unwrap();
+    }
+
+    #[test]
+    #[ignore = "requires an F16-token-embedding RMI_QWEN35_MODEL"]
+    fn qwen35_f16_token_embedding_model_loads() {
+        let path = std::env::var("RMI_QWEN35_MODEL").expect("RMI_QWEN35_MODEL must be set");
+        let source = crate::open_model_source(
+            std::path::Path::new(&path),
+            crate::ComponentRole::Llm,
+        )
+        .unwrap();
+
+        assert_eq!(
+            source.tensor_info("token_embd.weight").unwrap().ggml_type,
+            GGMLType::F16,
         );
         Qwen35Model::from_source(source.as_ref()).unwrap();
     }

--- a/RustModelInference/src/qwen35.rs
+++ b/RustModelInference/src/qwen35.rs
@@ -1,7 +1,7 @@
 use rayon::prelude::*;
 
 use crate::clip_config::Qwen35Config;
-use crate::model::{GGUFLoader, GGMLType};
+use crate::model::{GGMLType, TensorSource};
 use crate::ops::{attention_value_f32, dot_f32, softmax, rope_neox, rope_mrope};
 #[cfg(feature = "parity-trace")]
 use crate::parity_trace;
@@ -566,9 +566,9 @@ impl QWeight {
     }
 }
 
-fn load_weight(loader: &GGUFLoader, name: &str) -> Option<QWeight> {
-    let ti = loader.tensor_info(name)?;
-    let data = loader.tensor_slice(name)?;
+fn load_weight<S: TensorSource + ?Sized>(source: &S, name: &str) -> Option<QWeight> {
+    let ti = source.tensor_info(name)?;
+    let data = source.tensor_slice(name)?;
     let n_cols = ti.dims[0] as usize;
     let n_rows = if ti.dims.len() >= 2 { ti.dims[1] as usize } else { 1 };
 
@@ -601,9 +601,9 @@ fn load_weight(loader: &GGUFLoader, name: &str) -> Option<QWeight> {
     }
 }
 
-fn load_weight_f32(loader: &GGUFLoader, name: &str) -> Option<Vec<f32>> {
-    let ti = loader.tensor_info(name)?;
-    let data = loader.tensor_slice(name)?;
+fn load_weight_f32<S: TensorSource + ?Sized>(source: &S, name: &str) -> Option<Vec<f32>> {
+    let ti = source.tensor_info(name)?;
+    let data = source.tensor_slice(name)?;
     let n_el = ti.n_elements();
     match ti.ggml_type {
         GGMLType::F32 => {
@@ -650,12 +650,12 @@ pub struct Qwen35LayerWeights {
 }
 
 impl Qwen35Model {
-    pub fn from_gguf(loader: &GGUFLoader) -> Result<Self, String> {
-        let config = Qwen35Config::from_gguf(loader)?;
+    pub fn from_source<S: TensorSource + ?Sized>(source: &S) -> Result<Self, String> {
+        let config = Qwen35Config::from_source(source)?;
 
         let tok_embd = {
-            let ti = loader.tensor_info("token_embd.weight").ok_or("Missing token_embd.weight")?;
-            let data = loader.tensor_slice("token_embd.weight").unwrap();
+            let ti = source.tensor_info("token_embd.weight").ok_or("Missing token_embd.weight")?;
+            let data = source.tensor_slice("token_embd.weight").unwrap();
             let n_cols = ti.dims[0] as usize;
             let n_rows = ti.dims[1] as usize;
             match ti.ggml_type {
@@ -665,51 +665,51 @@ impl Qwen35Model {
             }
         };
 
-        let output_norm = load_weight_f32(loader, "output_norm.weight").ok_or("Missing output_norm.weight")?;
+        let output_norm = load_weight_f32(source, "output_norm.weight").ok_or("Missing output_norm.weight")?;
 
         let output_weight = {
-            let name = if loader.tensor_info("output.weight").is_some() { "output.weight" } else { "token_embd.weight" };
-            load_weight(loader, name).ok_or("Missing output weight")?
+            let name = if source.tensor_info("output.weight").is_some() { "output.weight" } else { "token_embd.weight" };
+            load_weight(source, name).ok_or("Missing output weight")?
         };
 
         let mut layers = Vec::with_capacity(config.n_layer);
         for i in 0..config.n_layer {
-            let attn_norm = load_weight_f32(loader, &format!("blk.{}.attn_norm.weight", i))
+            let attn_norm = load_weight_f32(source, &format!("blk.{}.attn_norm.weight", i))
                 .ok_or_else(|| format!("Missing blk.{}.attn_norm.weight", i))?;
-            let attn_post_norm = load_weight_f32(loader, &format!("blk.{}.post_attention_norm.weight", i))
+            let attn_post_norm = load_weight_f32(source, &format!("blk.{}.post_attention_norm.weight", i))
                 .ok_or_else(|| format!("Missing blk.{}.post_attention_norm.weight", i))?;
             let is_recr = config.is_recurrent[i];
 
             let (wq, wk, wv, wo, attn_q_norm, attn_k_norm) = if !is_recr {
                 (
-                    load_weight(loader, &format!("blk.{}.attn_q.weight", i)),
-                    load_weight(loader, &format!("blk.{}.attn_k.weight", i)),
-                    load_weight(loader, &format!("blk.{}.attn_v.weight", i)),
-                    load_weight(loader, &format!("blk.{}.attn_output.weight", i)),
-                    load_weight_f32(loader, &format!("blk.{}.attn_q_norm.weight", i)),
-                    load_weight_f32(loader, &format!("blk.{}.attn_k_norm.weight", i)),
+                    load_weight(source, &format!("blk.{}.attn_q.weight", i)),
+                    load_weight(source, &format!("blk.{}.attn_k.weight", i)),
+                    load_weight(source, &format!("blk.{}.attn_v.weight", i)),
+                    load_weight(source, &format!("blk.{}.attn_output.weight", i)),
+                    load_weight_f32(source, &format!("blk.{}.attn_q_norm.weight", i)),
+                    load_weight_f32(source, &format!("blk.{}.attn_k_norm.weight", i)),
                 )
             } else { (None, None, None, None, None, None) };
 
             let (wqkv, wqkv_gate, ssm_conv1d, ssm_dt, ssm_a, ssm_beta, ssm_alpha, ssm_norm, ssm_out) = if is_recr {
                 (
-                    load_weight(loader, &format!("blk.{}.attn_qkv.weight", i)),
-                    load_weight(loader, &format!("blk.{}.attn_gate.weight", i)),
-                    load_weight_f32(loader, &format!("blk.{}.ssm_conv1d.weight", i)),
-                    load_weight_f32(loader, &format!("blk.{}.ssm_dt.bias", i)),
-                    load_weight_f32(loader, &format!("blk.{}.ssm_a", i)),
-                    load_weight(loader, &format!("blk.{}.ssm_beta.weight", i)),
-                    load_weight(loader, &format!("blk.{}.ssm_alpha.weight", i)),
-                    load_weight_f32(loader, &format!("blk.{}.ssm_norm.weight", i)),
-                    load_weight(loader, &format!("blk.{}.ssm_out.weight", i)),
+                    load_weight(source, &format!("blk.{}.attn_qkv.weight", i)),
+                    load_weight(source, &format!("blk.{}.attn_gate.weight", i)),
+                    load_weight_f32(source, &format!("blk.{}.ssm_conv1d.weight", i)),
+                    load_weight_f32(source, &format!("blk.{}.ssm_dt.bias", i)),
+                    load_weight_f32(source, &format!("blk.{}.ssm_a", i)),
+                    load_weight(source, &format!("blk.{}.ssm_beta.weight", i)),
+                    load_weight(source, &format!("blk.{}.ssm_alpha.weight", i)),
+                    load_weight_f32(source, &format!("blk.{}.ssm_norm.weight", i)),
+                    load_weight(source, &format!("blk.{}.ssm_out.weight", i)),
                 )
             } else { (None, None, None, None, None, None, None, None, None) };
 
-            let ffn_gate = load_weight(loader, &format!("blk.{}.ffn_gate.weight", i))
+            let ffn_gate = load_weight(source, &format!("blk.{}.ffn_gate.weight", i))
                 .ok_or_else(|| format!("Missing blk.{}.ffn_gate.weight", i))?;
-            let ffn_up = load_weight(loader, &format!("blk.{}.ffn_up.weight", i))
+            let ffn_up = load_weight(source, &format!("blk.{}.ffn_up.weight", i))
                 .ok_or_else(|| format!("Missing blk.{}.ffn_up.weight", i))?;
-            let ffn_down = load_weight(loader, &format!("blk.{}.ffn_down.weight", i))
+            let ffn_down = load_weight(source, &format!("blk.{}.ffn_down.weight", i))
                 .ok_or_else(|| format!("Missing blk.{}.ffn_down.weight", i))?;
             let ffn_gate_up = QWeight::fuse_vstack(&ffn_gate, &ffn_up);
 
@@ -1660,13 +1660,17 @@ mod tests {
     #[ignore = "requires RMI_QWEN35_MODEL"]
     fn qwen35_q8_0_model_loads() {
         let path = std::env::var("RMI_QWEN35_MODEL").expect("RMI_QWEN35_MODEL must be set");
-        let loader = GGUFLoader::from_file(&path).unwrap();
+        let source = crate::open_model_source(
+            std::path::Path::new(&path),
+            crate::ComponentRole::Llm,
+        )
+        .unwrap();
 
         assert_eq!(
-            loader.tensor_info("token_embd.weight").unwrap().ggml_type,
+            source.tensor_info("token_embd.weight").unwrap().ggml_type,
             GGMLType::Q8_0,
         );
-        Qwen35Model::from_gguf(&loader).unwrap();
+        Qwen35Model::from_source(source.as_ref()).unwrap();
     }
 
     #[test]

--- a/RustModelInference/src/vision.rs
+++ b/RustModelInference/src/vision.rs
@@ -1,5 +1,5 @@
 use crate::clip_config::ClipVisionConfig;
-use crate::model::GGUFLoader;
+use crate::model::TensorSource;
 use crate::ops::{dot_f32, dot_f16_f32, rope_mrope_interleaved, softmax, vec_mad_f32};
 use rayon::prelude::*;
 
@@ -254,37 +254,37 @@ pub struct VisionLayer<'a> {
 }
 
 impl<'a> VisionEncoder<'a> {
-    pub fn from_gguf(loader: &'a GGUFLoader) -> Result<Self, String> {
-        let config = ClipVisionConfig::from_gguf(loader)?;
+    pub fn from_source<S: TensorSource + ?Sized>(source: &'a S) -> Result<Self, String> {
+        let config = ClipVisionConfig::from_source(source)?;
 
-        let patch_embd_weight = loader.tensor_slice("v.patch_embd.weight")
+        let patch_embd_weight = source.tensor_slice("v.patch_embd.weight")
             .ok_or("Missing v.patch_embd.weight")?;
-        let patch_embd_weight_1 = loader.tensor_slice("v.patch_embd.weight.1");
-        let position_embd = loader.tensor_slice("v.position_embd.weight");
-        let post_ln_weight = loader.tensor_slice("v.post_ln.weight");
-        let post_ln_bias = loader.tensor_slice("v.post_ln.bias");
-        let patch_bias = loader.tensor_slice("v.patch_embd.bias");
+        let patch_embd_weight_1 = source.tensor_slice("v.patch_embd.weight.1");
+        let position_embd = source.tensor_slice("v.position_embd.weight");
+        let post_ln_weight = source.tensor_slice("v.post_ln.weight");
+        let post_ln_bias = source.tensor_slice("v.post_ln.bias");
+        let patch_bias = source.tensor_slice("v.patch_embd.bias");
 
         let mut layers = Vec::with_capacity(config.n_layer);
         for i in 0..config.n_layer {
-            let ln1_weight = loader.tensor_slice(&format!("v.blk.{}.ln1.weight", i))
+            let ln1_weight = source.tensor_slice(&format!("v.blk.{}.ln1.weight", i))
                 .ok_or_else(|| format!("Missing v.blk.{}.ln1.weight", i))?;
-            let ln1_bias = loader.tensor_slice(&format!("v.blk.{}.ln1.bias", i));
-            let ln2_weight = loader.tensor_slice(&format!("v.blk.{}.ln2.weight", i))
+            let ln1_bias = source.tensor_slice(&format!("v.blk.{}.ln1.bias", i));
+            let ln2_weight = source.tensor_slice(&format!("v.blk.{}.ln2.weight", i))
                 .ok_or_else(|| format!("Missing v.blk.{}.ln2.weight", i))?;
-            let ln2_bias = loader.tensor_slice(&format!("v.blk.{}.ln2.bias", i));
-            let qkv_weight = loader.tensor_slice(&format!("v.blk.{}.attn_qkv.weight", i))
+            let ln2_bias = source.tensor_slice(&format!("v.blk.{}.ln2.bias", i));
+            let qkv_weight = source.tensor_slice(&format!("v.blk.{}.attn_qkv.weight", i))
                 .ok_or_else(|| format!("Missing v.blk.{}.attn_qkv.weight", i))?;
-            let qkv_bias = loader.tensor_slice(&format!("v.blk.{}.attn_qkv.bias", i));
-            let out_weight = loader.tensor_slice(&format!("v.blk.{}.attn_out.weight", i))
+            let qkv_bias = source.tensor_slice(&format!("v.blk.{}.attn_qkv.bias", i));
+            let out_weight = source.tensor_slice(&format!("v.blk.{}.attn_out.weight", i))
                 .ok_or_else(|| format!("Missing v.blk.{}.attn_out.weight", i))?;
-            let out_bias = loader.tensor_slice(&format!("v.blk.{}.attn_out.bias", i));
-            let ffn_up_weight = loader.tensor_slice(&format!("v.blk.{}.ffn_up.weight", i))
+            let out_bias = source.tensor_slice(&format!("v.blk.{}.attn_out.bias", i));
+            let ffn_up_weight = source.tensor_slice(&format!("v.blk.{}.ffn_up.weight", i))
                 .ok_or_else(|| format!("Missing v.blk.{}.ffn_up.weight", i))?;
-            let ffn_up_bias = loader.tensor_slice(&format!("v.blk.{}.ffn_up.bias", i));
-            let ffn_down_weight = loader.tensor_slice(&format!("v.blk.{}.ffn_down.weight", i))
+            let ffn_up_bias = source.tensor_slice(&format!("v.blk.{}.ffn_up.bias", i));
+            let ffn_down_weight = source.tensor_slice(&format!("v.blk.{}.ffn_down.weight", i))
                 .ok_or_else(|| format!("Missing v.blk.{}.ffn_down.weight", i))?;
-            let ffn_down_bias = loader.tensor_slice(&format!("v.blk.{}.ffn_down.bias", i));
+            let ffn_down_bias = source.tensor_slice(&format!("v.blk.{}.ffn_down.bias", i));
 
             layers.push(VisionLayer {
                 ln1_weight, ln1_bias,
@@ -296,12 +296,12 @@ impl<'a> VisionEncoder<'a> {
             });
         }
 
-        let mm_0_weight = loader.tensor_slice("mm.0.weight")
+        let mm_0_weight = source.tensor_slice("mm.0.weight")
             .ok_or("Missing mm.0.weight")?;
-        let mm_0_bias = loader.tensor_slice("mm.0.bias");
-        let mm_2_weight = loader.tensor_slice("mm.2.weight")
+        let mm_0_bias = source.tensor_slice("mm.0.bias");
+        let mm_2_weight = source.tensor_slice("mm.2.weight")
             .ok_or("Missing mm.2.weight")?;
-        let mm_2_bias = loader.tensor_slice("mm.2.bias");
+        let mm_2_bias = source.tensor_slice("mm.2.bias");
 
         Ok(Self {
             config,

--- a/RustModelInference/tests/embedding_parity.rs
+++ b/RustModelInference/tests/embedding_parity.rs
@@ -33,15 +33,16 @@ fn run(command: &mut Command) -> String {
     String::from_utf8(output.stdout).unwrap()
 }
 
-fn rust_embedding_model(reference_model: &str) -> String {
-    std::env::var("RMI_RUST_EMBEDDING_MODEL").unwrap_or_else(|_| reference_model.to_string())
+fn rust_embedding_model(reference_model: &str, override_model: Option<&str>) -> String {
+    override_model.unwrap_or(reference_model).to_string()
 }
 
 #[test]
 #[ignore = "requires QWEN3_EMBEDDING_MODEL and LLAMA_EMBEDDING_BIN"]
 fn qwen3_embedding_vectors_match_pinned_llama_cpp() {
     let model = std::env::var("QWEN3_EMBEDDING_MODEL").unwrap();
-    let rust_model = rust_embedding_model(&model);
+    let rust_model_override = std::env::var("RMI_RUST_EMBEDDING_MODEL").ok();
+    let rust_model = rust_embedding_model(&model, rust_model_override.as_deref());
     let llama = std::env::var("LLAMA_EMBEDDING_BIN").unwrap();
     let rust = env!("CARGO_BIN_EXE_rust-model-inference");
     let mut rust_vectors = Vec::new();
@@ -134,15 +135,10 @@ fn qwen3_embedding_vectors_match_pinned_llama_cpp() {
 }
 
 #[test]
-fn rust_embedding_model_uses_the_package_override() {
-    let variable = "RMI_RUST_EMBEDDING_MODEL";
-    let previous = std::env::var_os(variable);
-    std::env::set_var(variable, "/tmp/model.ggufrs");
-
-    assert_eq!(rust_embedding_model("model.gguf"), "/tmp/model.ggufrs");
-
-    match previous {
-        Some(value) => std::env::set_var(variable, value),
-        None => std::env::remove_var(variable),
-    }
+fn rust_embedding_model_resolves_override_and_fallback() {
+    assert_eq!(
+        rust_embedding_model("model.gguf", Some("/tmp/model.ggufrs")),
+        "/tmp/model.ggufrs"
+    );
+    assert_eq!(rust_embedding_model("model.gguf", None), "model.gguf");
 }

--- a/RustModelInference/tests/embedding_parity.rs
+++ b/RustModelInference/tests/embedding_parity.rs
@@ -33,10 +33,15 @@ fn run(command: &mut Command) -> String {
     String::from_utf8(output.stdout).unwrap()
 }
 
+fn rust_embedding_model(reference_model: &str) -> String {
+    std::env::var("RMI_RUST_EMBEDDING_MODEL").unwrap_or_else(|_| reference_model.to_string())
+}
+
 #[test]
 #[ignore = "requires QWEN3_EMBEDDING_MODEL and LLAMA_EMBEDDING_BIN"]
 fn qwen3_embedding_vectors_match_pinned_llama_cpp() {
     let model = std::env::var("QWEN3_EMBEDDING_MODEL").unwrap();
+    let rust_model = rust_embedding_model(&model);
     let llama = std::env::var("LLAMA_EMBEDDING_BIN").unwrap();
     let rust = env!("CARGO_BIN_EXE_rust-model-inference");
     let mut rust_vectors = Vec::new();
@@ -45,7 +50,7 @@ fn qwen3_embedding_vectors_match_pinned_llama_cpp() {
     for &prompt in FIXTURES {
         let rust_stdout = run(Command::new(rust).args([
             "--model",
-            &model,
+            &rust_model,
             "--prompt",
             prompt,
             "--embedding",
@@ -126,4 +131,18 @@ fn qwen3_embedding_vectors_match_pinned_llama_cpp() {
         max_matrix_diff <= 1e-3,
         "cosine matrix max diff={max_matrix_diff}"
     );
+}
+
+#[test]
+fn rust_embedding_model_uses_the_package_override() {
+    let variable = "RMI_RUST_EMBEDDING_MODEL";
+    let previous = std::env::var_os(variable);
+    std::env::set_var(variable, "/tmp/model.ggufrs");
+
+    assert_eq!(rust_embedding_model("model.gguf"), "/tmp/model.ggufrs");
+
+    match previous {
+        Some(value) => std::env::set_var(variable, value),
+        None => std::env::remove_var(variable),
+    }
 }


### PR DESCRIPTION
## Summary

This follow-up completes Problem 3 by adding RustModelInference's own `.ggufrs` package format for model management and device-independent loading.

- bundle exactly one LLM GGUF and optionally one mmproj with component-scoped metadata
- preserve every source tensor byte without dequantization, requantization, or repacking
- index 64 KiB-aligned, independently verified/mapped/released segments
- load GGUF and GGUFRS through the shared `TensorSource` contract
- build deterministic `LayerSplit` and `TensorSplit` plans for logical CPU devices
- export through the strict standard-library `ggufrs export` CLI
- document the v1 on-disk format in `RustModelInference/GGUFRS.md`

Real GPU/NPU backends, transfers, and execution scheduling remain intentionally deferred; v1 validates placement and mapping lifetimes using logical CPU devices.

## Why

Plain GGUF is useful for interchange, but RustModelInference needs a package that can keep the LLM and mmproj together while retaining separate metadata namespaces and allowing segment-level placement/lifetime management across future devices. Appending mmproj data after a GGUF would make indexing and ownership ambiguous, so GGUFRS uses a versioned superblock and explicit component, metadata, segment, and tensor tables before aligned tensor data.

## Safety and compatibility

- exact `GGUFRS\0\0` magic is checked before the shared `GGUF` prefix
- all disk offsets, lengths, shapes, counts, table ranges, and tensor ranges are checked
- segment SHA-256 covers tensor bytes and canonical zero padding
- default export never clobbers an existing output; overwrite publishes only after production-reader validation
- malformed nested metadata arrays and noncanonical component names are rejected
- existing GGUF loading remains supported by magic-based dispatch

## Validation

- `cargo test --all-targets`: 142 passed, 0 failed, 17 ignored
- `RUSTFLAGS='' cargo check --target x86_64-apple-darwin --all-targets`: passed
- target-file rustfmt and git diff checks: passed
- GGUFRS reader/export tests: 38 passed
- LoadPlan tests: 12 passed
- Qwen3-0.6B-Q8_0: two independent 611 MiB exports were byte-identical
- Qwen3 original GGUF vs GGUFRS: 128-token logits dumps were byte-identical
- Qwen3 original GGUF Rust vs pinned llama.cpp: 128-token parity gate passed
- Qwen3-Embedding-0.6B-Q8_0: GGUFRS-backed Rust vectors matched the pinned llama.cpp original-GGUF gate across all fixtures and cosine thresholds
- NEON micro-bench check: 8.146x scalar speedup on the validation machine

The optional bundled Qwen3.5 mmproj parity gate was not run because the required model, mmproj, and image fixture variables were not present. No internal `docs/superpowers/` files are included in this PR.
