### PR TITLE
fix: bit-align Qwen3 embeddings with llama.cpp

### DIFF
--- a/RustModelInference/src/main.rs
+++ b/RustModelInference/src/main.rs
@@ -1287,6 +1287,8 @@ fn run_embedding(
     }
 
     let prompt_tokens = encode_embedding_input(&tokenizer, prompt);
+    #[cfg(feature = "parity-trace")]
+    parity_trace::report(parity_trace::token_ids("embedding.tokens", &prompt_tokens));
     if prompt_tokens.is_empty() {
         eprintln!("Embedding input produced no tokens");
         std::process::exit(1);

--- a/RustModelInference/src/main.rs
+++ b/RustModelInference/src/main.rs
@@ -516,10 +516,20 @@ mod cli_tests {
     }
 
     #[test]
-    fn embedding_l2_normalizes_subnormal_vector() {
+    fn embedding_l2_matches_llama_f32_product_and_scale_bits() {
+        let mut values = [1.0f32, 3.0];
+        l2_normalize_embedding(&mut values).unwrap();
+        assert_eq!(
+            values.map(f32::to_bits),
+            [0x3ea1e89b, 0x3f72dce8],
+        );
+    }
+
+    #[test]
+    fn embedding_l2_matches_llama_subnormal_underflow_to_zero() {
         let mut values = [f32::from_bits(1)];
         l2_normalize_embedding(&mut values).unwrap();
-        assert_eq!(values, [1.0]);
+        assert_eq!(values, [0.0]);
     }
 
     #[test]
@@ -1157,21 +1167,19 @@ fn l2_normalize_embedding(values: &mut [f32]) -> Result<(), String> {
         return Err("Embedding contains a non-finite value".into());
     }
 
-    let norm = values
+    let sum = values
         .iter()
-        .map(|&value| {
-            let value = f64::from(value);
-            value * value
-        })
-        .sum::<f64>()
-        .sqrt();
+        .map(|&value| f64::from(value * value))
+        .sum::<f64>();
 
-    if norm == 0.0 {
-        return Ok(());
-    }
+    let scale = if sum > 0.0 {
+        (1.0 / sum.sqrt()) as f32
+    } else {
+        0.0
+    };
 
     for value in values.iter_mut() {
-        *value = (f64::from(*value) / norm) as f32;
+        *value *= scale;
     }
 
     if values.iter().any(|value| !value.is_finite()) {

--- a/RustModelInference/src/main.rs
+++ b/RustModelInference/src/main.rs
@@ -1489,10 +1489,26 @@ fn run_embedding(
             eprintln!("Embedding pooling error: {error}");
             std::process::exit(1);
         });
+    #[cfg(feature = "parity-trace")]
+    parity_trace::report(parity_trace::checkpoint(
+        "embedding.pooled",
+        None,
+        &[n_embd],
+        &pooled,
+    ));
+
     l2_normalize_embedding(&mut pooled).unwrap_or_else(|error| {
         eprintln!("Embedding normalization error: {error}");
         std::process::exit(1);
     });
+
+    #[cfg(feature = "parity-trace")]
+    parity_trace::report(parity_trace::checkpoint(
+        "embedding.final",
+        None,
+        &[n_embd],
+        &pooled,
+    ));
 
     let embed_ms = t_embed.elapsed().as_millis();
     match output {

--- a/RustModelInference/src/main.rs
+++ b/RustModelInference/src/main.rs
@@ -1322,6 +1322,14 @@ fn run_embedding(
             .unwrap_or_else(|error| panic!("Failed to read embedding token row: {error}"));
     }
 
+    #[cfg(feature = "parity-trace")]
+    parity_trace::report(parity_trace::checkpoint(
+        "embedding.inp_embd",
+        None,
+        &[n_tokens, n_embd],
+        &hidden,
+    ));
+
     eprintln!(
         "DEBUG: initial embedding[0:8] = {:?}, n_embd={}, token_id={}",
         &hidden[..8],
@@ -1448,6 +1456,14 @@ fn run_embedding(
             }
         }
 
+        #[cfg(feature = "parity-trace")]
+        parity_trace::report(parity_trace::checkpoint(
+            "embedding.ffn_inp",
+            Some(layer),
+            &[n_tokens, n_embd],
+            &hidden,
+        ));
+
         for t in 0..n_tokens {
             rms_norm(
                 &hidden[t * n_embd..(t + 1) * n_embd],
@@ -1471,6 +1487,14 @@ fn run_embedding(
             &mut activation_scratch,
         )
         .unwrap_or_else(|error| panic!("Embedding FFN failed: {error}"));
+
+        #[cfg(feature = "parity-trace")]
+        parity_trace::report(parity_trace::checkpoint(
+            "embedding.l_out",
+            Some(layer),
+            &[n_tokens, n_embd],
+            &hidden,
+        ));
     }
 
     for t in 0..n_tokens {
@@ -1483,6 +1507,14 @@ fn run_embedding(
         );
         x.copy_from_slice(&normed[t * n_embd..(t + 1) * n_embd]);
     }
+
+    #[cfg(feature = "parity-trace")]
+    parity_trace::report(parity_trace::checkpoint(
+        "embedding.result_norm",
+        None,
+        &[n_tokens, n_embd],
+        &hidden,
+    ));
 
     let mut pooled = pool_embedding_rows(&hidden, n_tokens, n_embd, embedding_cfg.pooling)
         .unwrap_or_else(|error| {

--- a/RustModelInference/tests/embedding_parity.rs
+++ b/RustModelInference/tests/embedding_parity.rs
@@ -45,6 +45,39 @@ fn f32_bits(bytes: &[u8]) -> Vec<u32> {
         .collect()
 }
 
+fn llama_token_ids(bytes: &[u8]) -> Vec<u32> {
+    assert_eq!(bytes.len() % 4, 0);
+    bytes
+        .chunks_exact(4)
+        .map(|bytes| {
+            let token = i32::from_le_bytes(bytes.try_into().unwrap());
+            u32::try_from(token).expect("llama token IDs must be nonnegative")
+        })
+        .collect()
+}
+
+fn rust_trace_token_ids(trace: &std::path::Path) -> Vec<u32> {
+    let record = std::fs::read_to_string(trace)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+        .find(|record| record["name"] == "embedding.tokens")
+        .expect("missing Rust embedding.tokens parity checkpoint");
+    record["token_ids"]
+        .as_array()
+        .expect("embedding.tokens checkpoint must contain token_ids")
+        .iter()
+        .map(|token| {
+            u32::try_from(
+                token
+                    .as_u64()
+                    .expect("embedding.tokens token ID must be an unsigned integer"),
+            )
+            .expect("embedding.tokens token ID must fit u32")
+        })
+        .collect()
+}
+
 fn first_bit_mismatch(left: &[u32], right: &[u32]) -> Option<(usize, u32, u32)> {
     assert_eq!(left.len(), right.len());
     left.iter()
@@ -66,7 +99,7 @@ fn reference_embedding_bits(
     prompt: &str,
     fixture: usize,
     normalize: i32,
-) -> Vec<u32> {
+) -> (Vec<u32>, Vec<u32>) {
     let directory = fixture_dir(&format!("llama-{normalize}"), fixture);
     let _ = std::fs::remove_dir_all(&directory);
     std::fs::create_dir_all(&directory).unwrap();
@@ -115,7 +148,15 @@ fn reference_embedding_bits(
         .unwrap()
         .to_str()
         .unwrap();
-    f32_bits(&std::fs::read(directory.join(format!("llamacpp-{stem}-embeddings.bin"))).unwrap())
+    (
+        f32_bits(
+            &std::fs::read(directory.join(format!("llamacpp-{stem}-embeddings.bin"))).unwrap(),
+        ),
+        llama_token_ids(
+            &std::fs::read(directory.join(format!("llamacpp-{stem}-embeddings-tokens.bin")))
+                .expect("reference llama-debug must write embedding token IDs"),
+        ),
+    )
 }
 
 fn rust_embedding_checkpoints(
@@ -123,14 +164,17 @@ fn rust_embedding_checkpoints(
     model: &str,
     prompt: &str,
     fixture: usize,
-) -> (Vec<u32>, Vec<u32>) {
+) -> (Vec<u32>, Vec<u32>, Vec<u32>) {
     let directory = fixture_dir("rust", fixture);
     let _ = std::fs::remove_dir_all(&directory);
     std::fs::create_dir_all(&directory).unwrap();
     let trace = directory.join("trace.jsonl");
     let output = std::process::Command::new(rust)
         .env("RMI_PARITY_TRACE", &trace)
-        .env("RMI_PARITY_FILTER", "embedding.pooled,embedding.final")
+        .env(
+            "RMI_PARITY_FILTER",
+            "embedding.tokens,embedding.pooled,embedding.final",
+        )
         .args([
             "--model",
             model,
@@ -150,6 +194,7 @@ fn rust_embedding_checkpoints(
         String::from_utf8_lossy(&output.stderr)
     );
     (
+        rust_trace_token_ids(&trace),
         f32_bits(&std::fs::read(format!("{}.embedding.pooled.f32", trace.display())).unwrap()),
         f32_bits(&std::fs::read(format!("{}.embedding.final.f32", trace.display())).unwrap()),
     )
@@ -253,7 +298,7 @@ fn qwen3_embedding_vectors_match_pinned_llama_cpp() {
 }
 
 #[test]
-#[ignore = "requires QWEN3_EMBEDDING_MODEL and LLAMA_DEBUG_BIN"]
+#[ignore = "requires QWEN3_EMBEDDING_MODEL and patched/token-compatible LLAMA_DEBUG_BIN"]
 fn qwen3_embedding_bits_match_pinned_llama_cpp() {
     let model = std::env::var("QWEN3_EMBEDDING_MODEL").unwrap();
     let rust_model_override = std::env::var("RMI_RUST_EMBEDDING_MODEL").ok();
@@ -263,10 +308,20 @@ fn qwen3_embedding_bits_match_pinned_llama_cpp() {
     let mut failures = Vec::new();
 
     for (fixture, &prompt) in FIXTURES.iter().enumerate() {
-        let reference_pooled = reference_embedding_bits(&llama_debug, &model, prompt, fixture, -1);
-        let reference_final = reference_embedding_bits(&llama_debug, &model, prompt, fixture, 2);
-        let (rust_pooled, rust_final) =
+        let (reference_pooled, reference_pooled_tokens) =
+            reference_embedding_bits(&llama_debug, &model, prompt, fixture, -1);
+        let (reference_final, reference_final_tokens) =
+            reference_embedding_bits(&llama_debug, &model, prompt, fixture, 2);
+        assert_eq!(
+            reference_pooled_tokens, reference_final_tokens,
+            "{prompt:?}: reference harness must match embedding tokenization"
+        );
+        let (rust_tokens, rust_pooled, rust_final) =
             rust_embedding_checkpoints(rust, &rust_model, prompt, fixture);
+        assert_eq!(
+            rust_tokens, reference_pooled_tokens,
+            "{prompt:?}: reference harness must match embedding tokenization"
+        );
         assert_eq!(rust_pooled.len(), 1024, "{prompt:?}");
         assert_eq!(rust_final.len(), 1024, "{prompt:?}");
         assert_eq!(reference_pooled.len(), 1024, "{prompt:?} reference pooled");

--- a/RustModelInference/tests/embedding_parity.rs
+++ b/RustModelInference/tests/embedding_parity.rs
@@ -37,6 +37,124 @@ fn rust_embedding_model(reference_model: &str, override_model: Option<&str>) -> 
     override_model.unwrap_or(reference_model).to_string()
 }
 
+fn f32_bits(bytes: &[u8]) -> Vec<u32> {
+    assert_eq!(bytes.len() % 4, 0);
+    bytes
+        .chunks_exact(4)
+        .map(|bytes| u32::from_le_bytes(bytes.try_into().unwrap()))
+        .collect()
+}
+
+fn first_bit_mismatch(left: &[u32], right: &[u32]) -> Option<(usize, u32, u32)> {
+    assert_eq!(left.len(), right.len());
+    left.iter()
+        .zip(right)
+        .enumerate()
+        .find_map(|(index, (&left, &right))| (left != right).then_some((index, left, right)))
+}
+
+fn fixture_dir(label: &str, fixture: usize) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!(
+        "rmi-embedding-bits-{}-{label}-{fixture}",
+        std::process::id()
+    ))
+}
+
+fn reference_embedding_bits(
+    llama_debug: &str,
+    model: &str,
+    prompt: &str,
+    fixture: usize,
+    normalize: i32,
+) -> Vec<u32> {
+    let directory = fixture_dir(&format!("llama-{normalize}"), fixture);
+    let _ = std::fs::remove_dir_all(&directory);
+    std::fs::create_dir_all(&directory).unwrap();
+    let normalize = normalize.to_string();
+    let output = std::process::Command::new(llama_debug)
+        .args([
+            "-m",
+            model,
+            "-p",
+            prompt,
+            "-t",
+            "1",
+            "-tb",
+            "1",
+            "-b",
+            "2048",
+            "-ub",
+            "512",
+            "-ngl",
+            "0",
+            "-fa",
+            "off",
+            "-ctk",
+            "f32",
+            "-ctv",
+            "f32",
+            "--embedding",
+            "--pooling",
+            "last",
+            "--embd-normalize",
+            &normalize,
+            "--no-warmup",
+            "--save-logits",
+            "--logits-output-dir",
+            directory.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stem = std::path::Path::new(model)
+        .file_stem()
+        .unwrap()
+        .to_str()
+        .unwrap();
+    f32_bits(&std::fs::read(directory.join(format!("llamacpp-{stem}-embeddings.bin"))).unwrap())
+}
+
+fn rust_embedding_checkpoints(
+    rust: &str,
+    model: &str,
+    prompt: &str,
+    fixture: usize,
+) -> (Vec<u32>, Vec<u32>) {
+    let directory = fixture_dir("rust", fixture);
+    let _ = std::fs::remove_dir_all(&directory);
+    std::fs::create_dir_all(&directory).unwrap();
+    let trace = directory.join("trace.jsonl");
+    let output = std::process::Command::new(rust)
+        .env("RMI_PARITY_TRACE", &trace)
+        .env("RMI_PARITY_FILTER", "embedding.pooled,embedding.final")
+        .args([
+            "--model",
+            model,
+            "--prompt",
+            prompt,
+            "--embedding",
+            "--threads",
+            "1",
+            "--embedding-output",
+            "raw",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    (
+        f32_bits(&std::fs::read(format!("{}.embedding.pooled.f32", trace.display())).unwrap()),
+        f32_bits(&std::fs::read(format!("{}.embedding.final.f32", trace.display())).unwrap()),
+    )
+}
+
 #[test]
 #[ignore = "requires QWEN3_EMBEDDING_MODEL and LLAMA_EMBEDDING_BIN"]
 fn qwen3_embedding_vectors_match_pinned_llama_cpp() {
@@ -132,6 +250,39 @@ fn qwen3_embedding_vectors_match_pinned_llama_cpp() {
         max_matrix_diff <= 1e-3,
         "cosine matrix max diff={max_matrix_diff}"
     );
+}
+
+#[test]
+#[ignore = "requires QWEN3_EMBEDDING_MODEL and LLAMA_DEBUG_BIN"]
+fn qwen3_embedding_bits_match_pinned_llama_cpp() {
+    let model = std::env::var("QWEN3_EMBEDDING_MODEL").unwrap();
+    let rust_model_override = std::env::var("RMI_RUST_EMBEDDING_MODEL").ok();
+    let rust_model = rust_embedding_model(&model, rust_model_override.as_deref());
+    let llama_debug = std::env::var("LLAMA_DEBUG_BIN").unwrap();
+    let rust = env!("CARGO_BIN_EXE_rust-model-inference");
+    let mut failures = Vec::new();
+
+    for (fixture, &prompt) in FIXTURES.iter().enumerate() {
+        let reference_pooled = reference_embedding_bits(&llama_debug, &model, prompt, fixture, -1);
+        let reference_final = reference_embedding_bits(&llama_debug, &model, prompt, fixture, 2);
+        let (rust_pooled, rust_final) =
+            rust_embedding_checkpoints(rust, &rust_model, prompt, fixture);
+        assert_eq!(rust_pooled.len(), 1024, "{prompt:?}");
+        assert_eq!(rust_final.len(), 1024, "{prompt:?}");
+        assert_eq!(reference_pooled.len(), 1024, "{prompt:?} reference pooled");
+        assert_eq!(reference_final.len(), 1024, "{prompt:?} reference final");
+        if let Some((index, rust, llama)) = first_bit_mismatch(&rust_pooled, &reference_pooled) {
+            failures.push(format!(
+                "{prompt:?} pooled[{index}]: rust=0x{rust:08x} llama=0x{llama:08x}"
+            ));
+        }
+        if let Some((index, rust, llama)) = first_bit_mismatch(&rust_final, &reference_final) {
+            failures.push(format!(
+                "{prompt:?} final[{index}]: rust=0x{rust:08x} llama=0x{llama:08x}"
+            ));
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
 }
 
 #[test]


### PR DESCRIPTION
## Problem

Qwen3 embedding inference was numerically close to llama.cpp but could still differ by one ULP. The exact oracle also needed to prove that both runtimes embedded the same token sequence before treating a vector mismatch as a numerical regression.

## Root cause

Rust normalized the pooled embedding with F64 products and division. llama.cpp instead rounds each square to F32, accumulates and square-roots sequentially in F64, rounds the reciprocal scale to F32, and multiplies each component in F32. That different operation order changes some final F32 words.

The stock `llama-debug` reference also omitted the model-configured EOS token, while Rust correctly produced `[14990, 151643]` for `hello`. A reference tool with that tokenization difference cannot serve as a bitwise numerical oracle.

## Changes

- match llama.cpp's L2 normalization operation order in the shared embedding normalization path
- export token IDs plus pooled and final embedding checkpoints through the existing `parity-trace` feature
- compare token IDs before any F32 word comparison
- compare six fixtures exactly at both pooled and final boundaries, covering 12,288 F32 words
- retain intermediate embedding checkpoints for first-divergence diagnosis

## Validation

Model: `Qwen3-Embedding-0.6B-f16.gguf`

Model SHA-256: `421a27e58d165478cc7acb984a688c2aa41404968b0203e7cd743ece44c54340`

Reference: llama.cpp `10331 (7ba604f1c)`

- `cargo test --all-targets`
- `RUSTFLAGS='' cargo check --target x86_64-apple-darwin --all-targets`
- six-fixture numerical embedding parity against `llama-embedding`
- six-fixture token-compatible exact oracle: pooled and final outputs are bit-identical for all 12,288 F32 words
- stock `llama-debug` negative check: rejected at the token contract before vector comparison
- `git diff --check upstream/main...HEAD`

Follow-up to #13.
